### PR TITLE
refactor: squad-based composition, recursive deps, fire-and-forget dispatch

### DIFF
--- a/commander/collect.go
+++ b/commander/collect.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -30,24 +31,41 @@ func (c *Commander) Scan() {
 	}
 	c.RecentFailures = 0
 	for _, op := range ops {
-		switch op.Status {
-		case "active":
+		if op.Status == "active" {
 			c.handleActive(op)
 		}
 	}
 }
 
 func (c *Commander) handleActive(op *Operation) {
-	// Check if process is still alive
-	if op.PID > 0 && !processAlive(op.PID) {
-		now := time.Now().UTC()
-		reason := "process_crashed"
+	// Process still running — nothing to do
+	if op.PID > 0 && processAlive(op.PID) {
+		// Track long-running operations for review
+		if op.DispatchedAt != nil && time.Since(*op.DispatchedAt) > 30*time.Minute {
+			c.RecentFailures++
+		}
+		return
+	}
+
+	// Process exited — check if Captain completed the operation
+	now := time.Now().UTC()
+	opDir := c.OperationDir(op.Squad, op.OperationID)
+	reportExists := fileExists(filepath.Join(opDir, "report.html"))
+	opCompleted := fileContains(c.OperationMDPath(op.Squad, op.OperationID), "status: completed")
+
+	if reportExists && opCompleted {
+		op.Status = "completed"
+		op.CompletedAt = &now
+		op.PID = 0
+	} else {
+		reason := "process_exited_without_completion"
 		op.Status = "failed"
 		op.FailedAt = &now
 		op.FailureReason = &reason
+		op.PID = 0
 		c.RecentFailures++
-		c.SaveOperation(op)
 	}
+	c.SaveOperation(op)
 }
 
 // ShouldReview determines if LLM review is needed
@@ -69,7 +87,6 @@ func (c *Commander) ShouldReview() bool {
 	return false
 }
 
-// processAlive checks if a PID is running
 func processAlive(pid int) bool {
 	if pid == 0 {
 		return false
@@ -78,8 +95,7 @@ func processAlive(pid int) bool {
 	if err != nil {
 		return false
 	}
-	err = process.Signal(nil)
-	return err == nil
+	return process.Signal(nil) == nil
 }
 
 // GetUnnotified returns completed/failed operations not yet notified
@@ -99,7 +115,7 @@ func (c *Commander) GetUnnotified() ([]*Operation, error) {
 
 // MarkNotified sets notified=true for an operation
 func (c *Commander) MarkNotified(opID string) error {
-	op, err := c.LoadOperation(opID)
+	op, err := c.findOperation(opID)
 	if err != nil {
 		return err
 	}

--- a/commander/commander.go
+++ b/commander/commander.go
@@ -1,43 +1,44 @@
 package commander
 
 import (
-	"encoding/json"
+	"bufio"
+	"crypto/rand"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
-// Operation represents a task's metadata (operation.json)
+// Operation represents a task parsed from OPERATION.md frontmatter
 type Operation struct {
 	OperationID   string     `json:"operation_id"`
+	Squad         string     `json:"squad"`
 	Brief         string     `json:"brief"`
 	Details       string     `json:"details,omitempty"`
-	Squad         string     `json:"squad,omitempty"`
-	SquadVersion  string     `json:"squad_version,omitempty"`
 	Status        string     `json:"status"`
 	PID           int        `json:"pid,omitempty"`
-	Source        string     `json:"source"`
-	SchedulerID   *string    `json:"scheduler_id,omitempty"`
-	RetryCount    int        `json:"retry_count"`
 	Notified      bool       `json:"notified"`
+	RetryCount    int        `json:"retry_count"`
+	Source        string     `json:"source"`
 	CreatedAt     time.Time  `json:"created_at"`
 	DispatchedAt  *time.Time `json:"dispatched_at,omitempty"`
 	CompletedAt   *time.Time `json:"completed_at,omitempty"`
 	FailedAt      *time.Time `json:"failed_at,omitempty"`
 	FailureReason *string    `json:"failure_reason,omitempty"`
+	Summary       string     `json:"summary,omitempty"`
 }
 
 // Schedule represents a recurring task definition
 type Schedule struct {
-	ID        string    `json:"id"`
-	Brief     string    `json:"brief"`
-	Details   string    `json:"details,omitempty"`
-	Squad     string    `json:"squad,omitempty"`
-	Cron      string    `json:"cron"`
-	NextRun   time.Time `json:"next_run"`
-	Enabled   bool      `json:"enabled"`
-	CreatedAt time.Time `json:"created_at"`
+	ID        string
+	Brief     string
+	Details   string
+	Squad     string
+	Cron      string
+	NextRun   time.Time
+	Enabled   bool
+	CreatedAt time.Time
 }
 
 // Commander is the core orchestrator
@@ -46,67 +47,68 @@ type Commander struct {
 	Iteration      int
 	RecentFailures int
 	RetryCount     map[string]int
+	MaxConcurrent  int
 }
 
 // New creates a new Commander instance
 func New(swatRoot string) *Commander {
-	// Expand ~ to home dir
-	if swatRoot[:2] == "~/" {
+	if len(swatRoot) >= 2 && swatRoot[:2] == "~/" {
 		home, _ := os.UserHomeDir()
 		swatRoot = filepath.Join(home, swatRoot[2:])
 	}
 	return &Commander{
-		SwatRoot:   swatRoot,
-		RetryCount: make(map[string]int),
+		SwatRoot:      swatRoot,
+		RetryCount:    make(map[string]int),
+		MaxConcurrent: 4,
 	}
 }
 
-// GenerateOpID creates a unique operation ID
+// GenerateOpID creates a unique operation ID (date-8hex)
 func GenerateOpID() string {
-	return fmt.Sprintf("%s-%04x", time.Now().UTC().Format("20060102"), time.Now().UnixNano()%0xFFFF)
+	b := make([]byte, 4)
+	rand.Read(b)
+	return fmt.Sprintf("%s-%08x", time.Now().UTC().Format("20060102"), b)
 }
 
-// OperationsDir returns the path to operations/
-func (c *Commander) OperationsDir() string {
-	return filepath.Join(c.SwatRoot, "operations")
+// SquadDir returns the path to a squad's runtime directory
+func (c *Commander) SquadDir(squad string) string {
+	return filepath.Join(c.SwatRoot, "squads", squad)
 }
 
-// OperationDir returns the path to a specific operation
-func (c *Commander) OperationDir(opID string) string {
-	return filepath.Join(c.OperationsDir(), opID)
+// OperationDir returns the path to a specific operation within its squad
+func (c *Commander) OperationDir(squad, opID string) string {
+	return filepath.Join(c.SquadDir(squad), "operations", opID)
 }
 
-// SaveOperation writes operation.json
+// OperationMDPath returns the path to OPERATION.md for an operation
+func (c *Commander) OperationMDPath(squad, opID string) string {
+	return filepath.Join(c.OperationDir(squad, opID), "OPERATION.md")
+}
+
+// SaveOperation writes OPERATION.md with frontmatter + body
 func (c *Commander) SaveOperation(op *Operation) error {
-	dir := c.OperationDir(op.OperationID)
+	dir := c.OperationDir(op.Squad, op.OperationID)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("create operation dir: %w", err)
 	}
-	data, err := json.MarshalIndent(op, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshal operation: %w", err)
-	}
-	return os.WriteFile(filepath.Join(dir, "operation.json"), data, 0644)
+	md := buildOperationFile(op)
+	return os.WriteFile(c.OperationMDPath(op.Squad, op.OperationID), []byte(md), 0644)
 }
 
-// LoadOperation reads operation.json
-func (c *Commander) LoadOperation(opID string) (*Operation, error) {
-	path := filepath.Join(c.OperationDir(opID), "operation.json")
+// LoadOperation reads and parses OPERATION.md
+func (c *Commander) LoadOperation(squad, opID string) (*Operation, error) {
+	path := c.OperationMDPath(squad, opID)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-	var op Operation
-	if err := json.Unmarshal(data, &op); err != nil {
-		return nil, err
-	}
-	return &op, nil
+	return parseOperationMD(string(data))
 }
 
-// ListOperations returns all operations
+// ListOperations returns all operations across all squads
 func (c *Commander) ListOperations() ([]*Operation, error) {
-	dir := c.OperationsDir()
-	entries, err := os.ReadDir(dir)
+	squadsDir := filepath.Join(c.SwatRoot, "squads")
+	squadEntries, err := os.ReadDir(squadsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -114,15 +116,146 @@ func (c *Commander) ListOperations() ([]*Operation, error) {
 		return nil, err
 	}
 	var ops []*Operation
-	for _, entry := range entries {
-		if !entry.IsDir() {
+	for _, se := range squadEntries {
+		if !se.IsDir() {
 			continue
 		}
-		op, err := c.LoadOperation(entry.Name())
+		opsDir := filepath.Join(squadsDir, se.Name(), "operations")
+		opEntries, err := os.ReadDir(opsDir)
 		if err != nil {
 			continue
 		}
-		ops = append(ops, op)
+		for _, oe := range opEntries {
+			if !oe.IsDir() {
+				continue
+			}
+			op, err := c.LoadOperation(se.Name(), oe.Name())
+			if err != nil {
+				continue
+			}
+			ops = append(ops, op)
+		}
 	}
 	return ops, nil
+}
+
+// --- OPERATION.md serialization ---
+
+func buildOperationFile(op *Operation) string {
+	var sb strings.Builder
+	sb.WriteString("---\n")
+	sb.WriteString(fmt.Sprintf("operation_id: %s\n", op.OperationID))
+	sb.WriteString(fmt.Sprintf("squad: %s\n", op.Squad))
+	sb.WriteString(fmt.Sprintf("brief: %s\n", op.Brief))
+	sb.WriteString(fmt.Sprintf("status: %s\n", op.Status))
+	sb.WriteString(fmt.Sprintf("source: %s\n", op.Source))
+	sb.WriteString(fmt.Sprintf("pid: %d\n", op.PID))
+	sb.WriteString(fmt.Sprintf("notified: %v\n", op.Notified))
+	sb.WriteString(fmt.Sprintf("retry_count: %d\n", op.RetryCount))
+	sb.WriteString(fmt.Sprintf("created_at: %s\n", op.CreatedAt.Format(time.RFC3339)))
+	writeOptionalTime(&sb, "dispatched_at", op.DispatchedAt)
+	writeOptionalTime(&sb, "completed_at", op.CompletedAt)
+	writeOptionalTime(&sb, "failed_at", op.FailedAt)
+	writeOptionalStr(&sb, "failure_reason", op.FailureReason)
+	writeOptionalStr(&sb, "summary", nilIfEmpty(op.Summary))
+	sb.WriteString("references: []\n")
+	sb.WriteString("---\n\n")
+	sb.WriteString("# OPERATION\n\n")
+	sb.WriteString("## Task\n\n")
+	sb.WriteString(op.Brief + "\n")
+	if op.Details != "" {
+		sb.WriteString("\n## Details\n\n")
+		sb.WriteString(op.Details + "\n")
+	}
+	return sb.String()
+}
+
+func writeOptionalTime(sb *strings.Builder, key string, t *time.Time) {
+	if t != nil {
+		sb.WriteString(fmt.Sprintf("%s: %s\n", key, t.Format(time.RFC3339)))
+	} else {
+		sb.WriteString(fmt.Sprintf("%s:\n", key))
+	}
+}
+
+func writeOptionalStr(sb *strings.Builder, key string, s *string) {
+	if s != nil && *s != "" {
+		sb.WriteString(fmt.Sprintf("%s: %s\n", key, *s))
+	} else {
+		sb.WriteString(fmt.Sprintf("%s:\n", key))
+	}
+}
+
+func nilIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+func parseOperationMD(content string) (*Operation, error) {
+	if !strings.HasPrefix(content, "---") {
+		return nil, fmt.Errorf("missing frontmatter")
+	}
+	end := strings.Index(content[3:], "\n---")
+	if end < 0 {
+		return nil, fmt.Errorf("unterminated frontmatter")
+	}
+	fm := content[4 : end+3]
+
+	op := &Operation{}
+	scanner := bufio.NewScanner(strings.NewReader(fm))
+	for scanner.Scan() {
+		line := scanner.Text()
+		idx := strings.Index(line, ":")
+		if idx < 0 {
+			continue
+		}
+		key := strings.TrimSpace(line[:idx])
+		val := strings.TrimSpace(line[idx+1:])
+		switch key {
+		case "operation_id":
+			op.OperationID = val
+		case "squad":
+			op.Squad = val
+		case "brief":
+			op.Brief = val
+		case "status":
+			op.Status = val
+		case "source":
+			op.Source = val
+		case "pid":
+			fmt.Sscanf(val, "%d", &op.PID)
+		case "notified":
+			op.Notified = val == "true"
+		case "retry_count":
+			fmt.Sscanf(val, "%d", &op.RetryCount)
+		case "created_at":
+			if t, err := time.Parse(time.RFC3339, val); err == nil {
+				op.CreatedAt = t
+			}
+		case "dispatched_at":
+			if t, err := time.Parse(time.RFC3339, val); err == nil {
+				op.DispatchedAt = &t
+			}
+		case "completed_at":
+			if t, err := time.Parse(time.RFC3339, val); err == nil {
+				op.CompletedAt = &t
+			}
+		case "failed_at":
+			if t, err := time.Parse(time.RFC3339, val); err == nil {
+				op.FailedAt = &t
+			}
+		case "failure_reason":
+			if val != "" {
+				op.FailureReason = &val
+			}
+		case "summary":
+			op.Summary = val
+		}
+	}
+	if op.OperationID == "" {
+		return nil, fmt.Errorf("missing operation_id in frontmatter")
+	}
+	return op, nil
 }

--- a/commander/commander.go
+++ b/commander/commander.go
@@ -47,7 +47,6 @@ type Commander struct {
 	Iteration      int
 	RecentFailures int
 	RetryCount     map[string]int
-	MaxConcurrent  int
 }
 
 // New creates a new Commander instance
@@ -57,9 +56,8 @@ func New(swatRoot string) *Commander {
 		swatRoot = filepath.Join(home, swatRoot[2:])
 	}
 	return &Commander{
-		SwatRoot:      swatRoot,
-		RetryCount:    make(map[string]int),
-		MaxConcurrent: 4,
+		SwatRoot:   swatRoot,
+		RetryCount: make(map[string]int),
 	}
 }
 
@@ -258,4 +256,45 @@ func parseOperationMD(content string) (*Operation, error) {
 		return nil, fmt.Errorf("missing operation_id in frontmatter")
 	}
 	return op, nil
+}
+
+// findOperation locates an operation by ID across all squads
+func (c *Commander) findOperation(opID string) (*Operation, error) {
+	ops, err := c.ListOperations()
+	if err != nil {
+		return nil, err
+	}
+	for _, op := range ops {
+		if op.OperationID == opID {
+			return op, nil
+		}
+	}
+	return nil, fmt.Errorf("operation %s not found", opID)
+}
+
+// ListSquads returns all installed squad blueprints
+func (c *Commander) ListSquads() ([]map[string]string, error) {
+	bpDir := filepath.Join(c.SwatRoot, "blueprints")
+	entries, err := os.ReadDir(filepath.Join(bpDir, "squads"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var squads []map[string]string
+	for _, entry := range entries {
+		if !entry.IsDir() || entry.Name() == "_framework" {
+			continue
+		}
+		info := map[string]string{"name": entry.Name()}
+		manifestPath := filepath.Join(bpDir, "squads", entry.Name(), "MANIFEST.md")
+		if data, err := os.ReadFile(manifestPath); err == nil {
+			if desc := extractFrontmatterField(string(data), "description"); desc != "" {
+				info["description"] = desc
+			}
+		}
+		squads = append(squads, info)
+	}
+	return squads, nil
 }

--- a/commander/compose.go
+++ b/commander/compose.go
@@ -1,0 +1,212 @@
+package commander
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// resolveDependencies recursively resolves all skill dependencies for a squad
+func (c *Commander) resolveDependencies(squad string) []string {
+	bpDir := filepath.Join(c.SwatRoot, "blueprints")
+	visited := make(map[string]bool)
+	var result []string
+
+	// Collect initial skills from protocol and manifest
+	var seeds []string
+	protocolPath := filepath.Join(bpDir, "squads", "_framework", "PROTOCOL.md")
+	if data, err := os.ReadFile(protocolPath); err == nil {
+		seeds = append(seeds, parseDependencyList(string(data), "skills")...)
+	}
+	manifestPath := filepath.Join(bpDir, "squads", squad, "MANIFEST.md")
+	if data, err := os.ReadFile(manifestPath); err == nil {
+		seeds = append(seeds, parseDependencyList(string(data), "skills")...)
+	}
+
+	// BFS to resolve transitive dependencies
+	queue := seeds
+	for len(queue) > 0 {
+		skill := queue[0]
+		queue = queue[1:]
+		if visited[skill] {
+			continue
+		}
+		visited[skill] = true
+		result = append(result, skill)
+
+		// Check skill's own dependencies
+		skillMD := filepath.Join(c.SwatRoot, "blueprints", "skills", skill, "SKILL.md")
+		if data, err := os.ReadFile(skillMD); err == nil {
+			for _, dep := range parseDependencyList(string(data), "skills") {
+				if !visited[dep] {
+					queue = append(queue, dep)
+				}
+			}
+		}
+	}
+	return result
+}
+
+// resolveMCPDependencies collects all MCP names from protocol, manifest, and transitive skills
+func (c *Commander) resolveMCPDependencies(squad string) []string {
+	bpDir := filepath.Join(c.SwatRoot, "blueprints")
+	seen := make(map[string]bool)
+	var result []string
+
+	// Protocol MCPs
+	if data, err := os.ReadFile(filepath.Join(bpDir, "squads", "_framework", "PROTOCOL.md")); err == nil {
+		for _, m := range parseDependencyList(string(data), "mcps") {
+			if !seen[m] {
+				seen[m] = true
+				result = append(result, m)
+			}
+		}
+	}
+	// Manifest MCPs
+	if data, err := os.ReadFile(filepath.Join(bpDir, "squads", squad, "MANIFEST.md")); err == nil {
+		for _, m := range parseDependencyList(string(data), "mcps") {
+			if !seen[m] {
+				seen[m] = true
+				result = append(result, m)
+			}
+		}
+	}
+	// Transitive MCPs from resolved skills
+	for _, skill := range c.resolveDependencies(squad) {
+		skillMD := filepath.Join(c.SwatRoot, "blueprints", "skills", skill, "SKILL.md")
+		if data, err := os.ReadFile(skillMD); err == nil {
+			for _, m := range parseDependencyList(string(data), "mcps") {
+				if !seen[m] {
+					seen[m] = true
+					result = append(result, m)
+				}
+			}
+		}
+	}
+	return result
+}
+
+// composeMCPConfig builds .mcp.json from individual MCP config files
+func composeMCPConfig(swatRoot string, mcps []string) string {
+	mcpsDir := filepath.Join(swatRoot, "blueprints", "mcps")
+	servers := make(map[string]string)
+	for _, name := range mcps {
+		path := filepath.Join(mcpsDir, name+".json")
+		if data, err := os.ReadFile(path); err == nil {
+			servers[name] = strings.TrimSpace(string(data))
+		}
+	}
+	if len(servers) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("{\n  \"mcpServers\": {\n")
+	i := 0
+	for name, config := range servers {
+		if i > 0 {
+			sb.WriteString(",\n")
+		}
+		sb.WriteString(fmt.Sprintf("    %q: %s", name, config))
+		i++
+	}
+	sb.WriteString("\n  }\n}\n")
+	return sb.String()
+}
+
+// parseDependencyList extracts a dependency list from frontmatter, e.g. "skills: [a, b]"
+func parseDependencyList(md, field string) []string {
+	if !strings.HasPrefix(md, "---") {
+		return nil
+	}
+	end := strings.Index(md[3:], "\n---")
+	if end < 0 {
+		return nil
+	}
+	fm := md[4 : end+3]
+	for _, line := range strings.Split(fm, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, field+":") {
+			val := strings.TrimSpace(strings.TrimPrefix(trimmed, field+":"))
+			val = strings.Trim(val, "[]")
+			if val == "" {
+				return nil
+			}
+			var deps []string
+			for _, d := range strings.Split(val, ",") {
+				d = strings.TrimSpace(d)
+				if d != "" {
+					deps = append(deps, d)
+				}
+			}
+			return deps
+		}
+	}
+	return nil
+}
+
+// assembleAgentsMD replaces placeholders in PROTOCOL.md with manifest sections
+func assembleAgentsMD(manifest, protocol, squadName string) string {
+	domain := extractSection(manifest, "## Domain")
+	boundary := extractSection(manifest, "## Boundary")
+	writeAccess := extractSection(manifest, "## Write Access")
+	playbook := extractSection(manifest, "## Squad Playbook")
+	version := extractFrontmatterField(manifest, "version")
+	if version == "" {
+		version = "1.0.0"
+	}
+
+	result := stripFrontmatter(protocol)
+	result = strings.ReplaceAll(result, "{SQUAD_NAME}", squadName)
+	result = strings.ReplaceAll(result, "{SQUAD_VERSION}", version)
+	result = strings.ReplaceAll(result, "{SQUAD_DOMAIN}", domain)
+	result = strings.ReplaceAll(result, "{SQUAD_BOUNDARY}", boundary)
+	result = strings.ReplaceAll(result, "{SQUAD_WRITE_ACCESS}", writeAccess)
+	result = strings.ReplaceAll(result, "{SQUAD_PLAYBOOK}", playbook)
+	return result
+}
+
+// extractSection extracts content under a markdown heading
+func extractSection(md, heading string) string {
+	idx := strings.Index(md, heading)
+	if idx < 0 {
+		return ""
+	}
+	content := md[idx+len(heading):]
+	if nextIdx := strings.Index(content, "\n## "); nextIdx >= 0 {
+		content = content[:nextIdx]
+	}
+	return strings.TrimSpace(content)
+}
+
+// extractFrontmatterField extracts a single field value from YAML frontmatter
+func extractFrontmatterField(md, field string) string {
+	if !strings.HasPrefix(md, "---") {
+		return ""
+	}
+	end := strings.Index(md[3:], "\n---")
+	if end < 0 {
+		return ""
+	}
+	fm := md[4 : end+3]
+	for _, line := range strings.Split(fm, "\n") {
+		if strings.HasPrefix(line, field+":") {
+			val := strings.TrimSpace(strings.TrimPrefix(line, field+":"))
+			val = strings.Trim(val, "\"")
+			return val
+		}
+	}
+	return ""
+}
+
+// stripFrontmatter removes YAML frontmatter from a markdown document
+func stripFrontmatter(md string) string {
+	if !strings.HasPrefix(md, "---") {
+		return md
+	}
+	end := strings.Index(md[3:], "---")
+	if end < 0 {
+		return md
+	}
+	return strings.TrimLeft(md[end+6:], "\n")
+}

--- a/commander/dispatch.go
+++ b/commander/dispatch.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-// Dispatch creates a new operation
+// Dispatch creates a new operation and launches it immediately
 func (c *Commander) Dispatch(brief, details, squad string) (*Operation, error) {
 	now := time.Now().UTC()
 	op := &Operation{
@@ -25,7 +25,7 @@ func (c *Commander) Dispatch(brief, details, squad string) (*Operation, error) {
 		return nil, err
 	}
 
-	// Launch immediately instead of waiting for BackgroundLoop
+	// Launch immediately
 	go func() {
 		if err := c.launchOne(op); err != nil {
 			now := time.Now().UTC()
@@ -61,53 +61,16 @@ func (c *Commander) Cancel(opID string) error {
 	return c.SaveOperation(op)
 }
 
-// Launch picks up queued operations and starts squad processes
-func (c *Commander) Launch() {
-	ops, err := c.ListOperations()
-	if err != nil {
-		return
-	}
-
-	activeCount := 0
-	for _, op := range ops {
-		if op.Status == "active" {
-			activeCount++
-		}
-	}
-
-	for _, op := range ops {
-		if op.Status != "queued" {
-			continue
-		}
-		if activeCount >= c.MaxConcurrent {
-			break
-		}
-		if err := c.launchOne(op); err != nil {
-			now := time.Now().UTC()
-			reason := fmt.Sprintf("launch_failed: %v", err)
-			op.Status = "failed"
-			op.FailedAt = &now
-			op.FailureReason = &reason
-			c.SaveOperation(op)
-			continue
-		}
-		activeCount++
-	}
-}
-
 // launchOne prepares the operation directory and starts a Copilot CLI process
 func (c *Commander) launchOne(op *Operation) error {
 	opDir := c.OperationDir(op.Squad, op.OperationID)
 
-	// Provision: assemble AGENTS.md, copy skills and INTEL
 	if err := c.provision(op, opDir); err != nil {
 		return fmt.Errorf("provision: %w", err)
 	}
 
-	// Build prompt
-	prompt := "Read AGENTS.md first to understand who you are and how to operate. Then follow the Captain Protocol."
+	prompt := "Begin operation. Read OPERATION.md for your task brief, then follow the protocol in AGENTS.md."
 
-	// Start Copilot CLI
 	cmd := exec.Command("copilot", "-p", prompt, "--allow-all-tools")
 	cmd.Dir = opDir
 
@@ -124,7 +87,6 @@ func (c *Commander) launchOne(op *Operation) error {
 		return fmt.Errorf("start copilot: %w", err)
 	}
 
-	// Update operation status
 	now := time.Now().UTC()
 	op.Status = "active"
 	op.PID = cmd.Process.Pid
@@ -136,7 +98,7 @@ func (c *Commander) launchOne(op *Operation) error {
 		return err
 	}
 
-	// Fire and forget — Scan() will check process status periodically
+	// Fire and forget — reap process to avoid zombie
 	go func() {
 		defer logFile.Close()
 		cmd.Wait()
@@ -145,7 +107,7 @@ func (c *Commander) launchOne(op *Operation) error {
 	return nil
 }
 
-// provision assembles AGENTS.md, copies skills and INTEL into the operation directory
+// provision assembles AGENTS.md, copies skills and MCPs into the operation directory
 func (c *Commander) provision(op *Operation, opDir string) error {
 	bpDir := filepath.Join(c.SwatRoot, "blueprints")
 	squadBP := filepath.Join(bpDir, "squads", op.Squad)
@@ -202,280 +164,4 @@ func (c *Commander) provision(op *Operation, opDir string) error {
 	}
 
 	return nil
-}
-
-// resolveDependencies recursively resolves all skill dependencies for a squad
-func (c *Commander) resolveDependencies(squad string) []string {
-	bpDir := filepath.Join(c.SwatRoot, "blueprints")
-	visited := make(map[string]bool)
-	var result []string
-
-	// Collect initial skills from protocol and manifest
-	var seeds []string
-	protocolPath := filepath.Join(bpDir, "squads", "_framework", "PROTOCOL.md")
-	if data, err := os.ReadFile(protocolPath); err == nil {
-		seeds = append(seeds, parseDependencyList(string(data), "skills")...)
-	}
-	manifestPath := filepath.Join(bpDir, "squads", squad, "MANIFEST.md")
-	if data, err := os.ReadFile(manifestPath); err == nil {
-		seeds = append(seeds, parseDependencyList(string(data), "skills")...)
-	}
-
-	// BFS to resolve transitive dependencies
-	queue := seeds
-	for len(queue) > 0 {
-		skill := queue[0]
-		queue = queue[1:]
-		if visited[skill] {
-			continue
-		}
-		visited[skill] = true
-		result = append(result, skill)
-
-		// Check skill's own dependencies
-		skillMD := filepath.Join(c.SwatRoot, "blueprints", "skills", skill, "SKILL.md")
-		if data, err := os.ReadFile(skillMD); err == nil {
-			for _, dep := range parseDependencyList(string(data), "skills") {
-				if !visited[dep] {
-					queue = append(queue, dep)
-				}
-			}
-		}
-	}
-	return result
-}
-
-// resolveMCPDependencies collects all MCP names from protocol and manifest
-func (c *Commander) resolveMCPDependencies(squad string) []string {
-	bpDir := filepath.Join(c.SwatRoot, "blueprints")
-	seen := make(map[string]bool)
-	var result []string
-
-	// Protocol MCPs
-	if data, err := os.ReadFile(filepath.Join(bpDir, "squads", "_framework", "PROTOCOL.md")); err == nil {
-		for _, m := range parseDependencyList(string(data), "mcps") {
-			if !seen[m] {
-				seen[m] = true
-				result = append(result, m)
-			}
-		}
-	}
-	// Manifest MCPs
-	if data, err := os.ReadFile(filepath.Join(bpDir, "squads", squad, "MANIFEST.md")); err == nil {
-		for _, m := range parseDependencyList(string(data), "mcps") {
-			if !seen[m] {
-				seen[m] = true
-				result = append(result, m)
-			}
-		}
-	}
-	// Transitive MCPs from resolved skills
-	for _, skill := range c.resolveDependencies(squad) {
-		skillMD := filepath.Join(c.SwatRoot, "blueprints", "skills", skill, "SKILL.md")
-		if data, err := os.ReadFile(skillMD); err == nil {
-			for _, m := range parseDependencyList(string(data), "mcps") {
-				if !seen[m] {
-					seen[m] = true
-					result = append(result, m)
-				}
-			}
-		}
-	}
-	return result
-}
-
-// composeMCPConfig builds .mcp.json from individual MCP config files
-func composeMCPConfig(swatRoot string, mcps []string) string {
-	mcpsDir := filepath.Join(swatRoot, "blueprints", "mcps")
-	servers := make(map[string]string)
-	for _, name := range mcps {
-		path := filepath.Join(mcpsDir, name+".json")
-		if data, err := os.ReadFile(path); err == nil {
-			servers[name] = strings.TrimSpace(string(data))
-		}
-	}
-	if len(servers) == 0 {
-		return ""
-	}
-	var sb strings.Builder
-	sb.WriteString("{\n  \"mcpServers\": {\n")
-	i := 0
-	for name, config := range servers {
-		if i > 0 {
-			sb.WriteString(",\n")
-		}
-		sb.WriteString(fmt.Sprintf("    %q: %s", name, config))
-		i++
-	}
-	sb.WriteString("\n  }\n}\n")
-	return sb.String()
-}
-
-// parseDependencyList extracts a dependency list from frontmatter, e.g. "skills: [a, b]"
-func parseDependencyList(md, field string) []string {
-	if !strings.HasPrefix(md, "---") {
-		return nil
-	}
-	end := strings.Index(md[3:], "\n---")
-	if end < 0 {
-		return nil
-	}
-	fm := md[4 : end+3]
-	// Find "  skills: [...]" or "  mcps: [...]"
-	for _, line := range strings.Split(fm, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, field+":") {
-			val := strings.TrimSpace(strings.TrimPrefix(trimmed, field+":"))
-			val = strings.Trim(val, "[]")
-			if val == "" {
-				return nil
-			}
-			var deps []string
-			for _, d := range strings.Split(val, ",") {
-				d = strings.TrimSpace(d)
-				if d != "" {
-					deps = append(deps, d)
-				}
-			}
-			return deps
-		}
-	}
-	return nil
-}
-
-// assembleAgentsMD replaces placeholders in PROTOCOL.md with manifest sections
-func assembleAgentsMD(manifest, protocol, squadName string) string {
-	domain := extractSection(manifest, "## Domain")
-	boundary := extractSection(manifest, "## Boundary")
-	writeAccess := extractSection(manifest, "## Write Access")
-	playbook := extractSection(manifest, "## Squad Playbook")
-	version := extractFrontmatterField(manifest, "version")
-	if version == "" {
-		version = "1.0.0"
-	}
-
-	result := stripFrontmatter(protocol)
-	result = strings.ReplaceAll(result, "{SQUAD_NAME}", squadName)
-	result = strings.ReplaceAll(result, "{SQUAD_VERSION}", version)
-	result = strings.ReplaceAll(result, "{SQUAD_DOMAIN}", domain)
-	result = strings.ReplaceAll(result, "{SQUAD_BOUNDARY}", boundary)
-	result = strings.ReplaceAll(result, "{SQUAD_WRITE_ACCESS}", writeAccess)
-	result = strings.ReplaceAll(result, "{SQUAD_PLAYBOOK}", playbook)
-	return result
-}
-
-// findOperation locates an operation by ID across all squads
-func (c *Commander) findOperation(opID string) (*Operation, error) {
-	ops, err := c.ListOperations()
-	if err != nil {
-		return nil, err
-	}
-	for _, op := range ops {
-		if op.OperationID == opID {
-			return op, nil
-		}
-	}
-	return nil, fmt.Errorf("operation %s not found", opID)
-}
-
-// ListSquads returns all installed squad blueprints
-func (c *Commander) ListSquads() ([]map[string]string, error) {
-	bpDir := filepath.Join(c.SwatRoot, "blueprints")
-	entries, err := os.ReadDir(filepath.Join(bpDir, "squads"))
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	var squads []map[string]string
-	for _, entry := range entries {
-		if !entry.IsDir() || entry.Name() == "_framework" {
-			continue
-		}
-		info := map[string]string{"name": entry.Name()}
-		manifestPath := filepath.Join(bpDir, "squads", entry.Name(), "MANIFEST.md")
-		if data, err := os.ReadFile(manifestPath); err == nil {
-			if desc := extractFrontmatterField(string(data), "description"); desc != "" {
-				info["description"] = desc
-			}
-		}
-		squads = append(squads, info)
-	}
-	return squads, nil
-}
-
-// --- helpers ---
-
-func extractSection(md, heading string) string {
-	idx := strings.Index(md, heading)
-	if idx < 0 {
-		return ""
-	}
-	content := md[idx+len(heading):]
-	if nextIdx := strings.Index(content, "\n## "); nextIdx >= 0 {
-		content = content[:nextIdx]
-	}
-	return strings.TrimSpace(content)
-}
-
-func extractFrontmatterField(md, field string) string {
-	if !strings.HasPrefix(md, "---") {
-		return ""
-	}
-	end := strings.Index(md[3:], "\n---")
-	if end < 0 {
-		return ""
-	}
-	fm := md[4 : end+3]
-	for _, line := range strings.Split(fm, "\n") {
-		if strings.HasPrefix(line, field+":") {
-			val := strings.TrimSpace(strings.TrimPrefix(line, field+":"))
-			val = strings.Trim(val, "\"")
-			return val
-		}
-	}
-	return ""
-}
-
-func stripFrontmatter(md string) string {
-	if !strings.HasPrefix(md, "---") {
-		return md
-	}
-	end := strings.Index(md[3:], "---")
-	if end < 0 {
-		return md
-	}
-	return strings.TrimLeft(md[end+6:], "\n")
-}
-
-func fileExists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
-}
-
-func fileContains(path, substr string) bool {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return false
-	}
-	return strings.Contains(string(data), substr)
-}
-
-func copyDir(src, dst string) error {
-	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		rel, _ := filepath.Rel(src, path)
-		target := filepath.Join(dst, rel)
-		if info.IsDir() {
-			return os.MkdirAll(target, 0755)
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(target, data, 0644)
-	})
 }

--- a/commander/dispatch.go
+++ b/commander/dispatch.go
@@ -1,6 +1,11 @@
 package commander
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -19,20 +24,458 @@ func (c *Commander) Dispatch(brief, details, squad string) (*Operation, error) {
 	if err := c.SaveOperation(op); err != nil {
 		return nil, err
 	}
+
+	// Launch immediately instead of waiting for BackgroundLoop
+	go func() {
+		if err := c.launchOne(op); err != nil {
+			now := time.Now().UTC()
+			reason := fmt.Sprintf("launch_failed: %v", err)
+			op.Status = "failed"
+			op.FailedAt = &now
+			op.FailureReason = &reason
+			c.SaveOperation(op)
+		}
+	}()
+
 	return op, nil
 }
 
-// Cancel marks an operation as failed
+// Cancel marks an operation as failed and kills the process if active
 func (c *Commander) Cancel(opID string) error {
-	op, err := c.LoadOperation(opID)
+	op, err := c.findOperation(opID)
 	if err != nil {
 		return err
 	}
 	now := time.Now().UTC()
 	reason := "cancelled_by_user"
+
+	if op.Status == "active" && op.PID > 0 {
+		if p, err := os.FindProcess(op.PID); err == nil {
+			p.Signal(os.Kill)
+		}
+	}
+
 	op.Status = "failed"
 	op.FailedAt = &now
 	op.FailureReason = &reason
-	// TODO: kill PID if active
 	return c.SaveOperation(op)
+}
+
+// Launch picks up queued operations and starts squad processes
+func (c *Commander) Launch() {
+	ops, err := c.ListOperations()
+	if err != nil {
+		return
+	}
+
+	activeCount := 0
+	for _, op := range ops {
+		if op.Status == "active" {
+			activeCount++
+		}
+	}
+
+	for _, op := range ops {
+		if op.Status != "queued" {
+			continue
+		}
+		if activeCount >= c.MaxConcurrent {
+			break
+		}
+		if err := c.launchOne(op); err != nil {
+			now := time.Now().UTC()
+			reason := fmt.Sprintf("launch_failed: %v", err)
+			op.Status = "failed"
+			op.FailedAt = &now
+			op.FailureReason = &reason
+			c.SaveOperation(op)
+			continue
+		}
+		activeCount++
+	}
+}
+
+// launchOne prepares the operation directory and starts a Copilot CLI process
+func (c *Commander) launchOne(op *Operation) error {
+	opDir := c.OperationDir(op.Squad, op.OperationID)
+
+	// Provision: assemble AGENTS.md, copy skills and INTEL
+	if err := c.provision(op, opDir); err != nil {
+		return fmt.Errorf("provision: %w", err)
+	}
+
+	// Build prompt
+	prompt := "Read AGENTS.md first to understand who you are and how to operate. Then follow the Captain Protocol."
+
+	// Start Copilot CLI
+	cmd := exec.Command("copilot", "-p", prompt, "--allow-all-tools")
+	cmd.Dir = opDir
+
+	logPath := filepath.Join(opDir, "copilot.log")
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		return fmt.Errorf("create log file: %w", err)
+	}
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	if err := cmd.Start(); err != nil {
+		logFile.Close()
+		return fmt.Errorf("start copilot: %w", err)
+	}
+
+	// Update operation status
+	now := time.Now().UTC()
+	op.Status = "active"
+	op.PID = cmd.Process.Pid
+	op.DispatchedAt = &now
+
+	if err := c.SaveOperation(op); err != nil {
+		cmd.Process.Kill()
+		logFile.Close()
+		return err
+	}
+
+	// Fire and forget — Scan() will check process status periodically
+	go func() {
+		defer logFile.Close()
+		cmd.Wait()
+	}()
+
+	return nil
+}
+
+// provision assembles AGENTS.md, copies skills and INTEL into the operation directory
+func (c *Commander) provision(op *Operation, opDir string) error {
+	bpDir := filepath.Join(c.SwatRoot, "blueprints")
+	squadBP := filepath.Join(bpDir, "squads", op.Squad)
+	frameworkDir := filepath.Join(bpDir, "squads", "_framework")
+
+	// Read squad manifest
+	manifest, err := os.ReadFile(filepath.Join(squadBP, "MANIFEST.md"))
+	if err != nil {
+		return fmt.Errorf("read manifest for squad %q: %w", op.Squad, err)
+	}
+
+	// Read protocol template
+	protocol, err := os.ReadFile(filepath.Join(frameworkDir, "PROTOCOL.md"))
+	if err != nil {
+		return fmt.Errorf("read protocol: %w", err)
+	}
+
+	// Assemble and write AGENTS.md
+	agentsMD := assembleAgentsMD(string(manifest), string(protocol), op.Squad)
+	if err := os.WriteFile(filepath.Join(opDir, "AGENTS.md"), []byte(agentsMD), 0644); err != nil {
+		return fmt.Errorf("write AGENTS.md: %w", err)
+	}
+
+	// Ensure squad runtime dir and INTEL.md exist
+	squadDir := c.SquadDir(op.Squad)
+	squadIntel := filepath.Join(squadDir, "INTEL.md")
+	if !fileExists(squadIntel) {
+		templateIntel := filepath.Join(frameworkDir, "INTEL.md")
+		if data, err := os.ReadFile(templateIntel); err == nil {
+			initialized := strings.ReplaceAll(string(data), "{SQUAD_NAME}", op.Squad)
+			os.MkdirAll(squadDir, 0755)
+			os.WriteFile(squadIntel, []byte(initialized), 0644)
+		}
+	}
+
+	// Compose .mcp.json from resolved MCP dependencies
+	resolvedMCPs := c.resolveMCPDependencies(op.Squad)
+	if len(resolvedMCPs) > 0 {
+		mcpConfig := composeMCPConfig(c.SwatRoot, resolvedMCPs)
+		if mcpConfig != "" {
+			os.WriteFile(filepath.Join(opDir, ".mcp.json"), []byte(mcpConfig), 0644)
+		}
+	}
+
+	// Copy skills (resolve dependencies recursively)
+	skillsRoot := filepath.Join(c.SwatRoot, "blueprints", "skills")
+	resolvedSkills := c.resolveDependencies(op.Squad)
+	destSkillsDir := filepath.Join(opDir, ".github", "skills")
+	for _, skill := range resolvedSkills {
+		srcSkill := filepath.Join(skillsRoot, skill)
+		if _, err := os.Stat(srcSkill); err == nil {
+			copyDir(srcSkill, filepath.Join(destSkillsDir, skill))
+		}
+	}
+
+	return nil
+}
+
+// resolveDependencies recursively resolves all skill dependencies for a squad
+func (c *Commander) resolveDependencies(squad string) []string {
+	bpDir := filepath.Join(c.SwatRoot, "blueprints")
+	visited := make(map[string]bool)
+	var result []string
+
+	// Collect initial skills from protocol and manifest
+	var seeds []string
+	protocolPath := filepath.Join(bpDir, "squads", "_framework", "PROTOCOL.md")
+	if data, err := os.ReadFile(protocolPath); err == nil {
+		seeds = append(seeds, parseDependencyList(string(data), "skills")...)
+	}
+	manifestPath := filepath.Join(bpDir, "squads", squad, "MANIFEST.md")
+	if data, err := os.ReadFile(manifestPath); err == nil {
+		seeds = append(seeds, parseDependencyList(string(data), "skills")...)
+	}
+
+	// BFS to resolve transitive dependencies
+	queue := seeds
+	for len(queue) > 0 {
+		skill := queue[0]
+		queue = queue[1:]
+		if visited[skill] {
+			continue
+		}
+		visited[skill] = true
+		result = append(result, skill)
+
+		// Check skill's own dependencies
+		skillMD := filepath.Join(c.SwatRoot, "blueprints", "skills", skill, "SKILL.md")
+		if data, err := os.ReadFile(skillMD); err == nil {
+			for _, dep := range parseDependencyList(string(data), "skills") {
+				if !visited[dep] {
+					queue = append(queue, dep)
+				}
+			}
+		}
+	}
+	return result
+}
+
+// resolveMCPDependencies collects all MCP names from protocol and manifest
+func (c *Commander) resolveMCPDependencies(squad string) []string {
+	bpDir := filepath.Join(c.SwatRoot, "blueprints")
+	seen := make(map[string]bool)
+	var result []string
+
+	// Protocol MCPs
+	if data, err := os.ReadFile(filepath.Join(bpDir, "squads", "_framework", "PROTOCOL.md")); err == nil {
+		for _, m := range parseDependencyList(string(data), "mcps") {
+			if !seen[m] {
+				seen[m] = true
+				result = append(result, m)
+			}
+		}
+	}
+	// Manifest MCPs
+	if data, err := os.ReadFile(filepath.Join(bpDir, "squads", squad, "MANIFEST.md")); err == nil {
+		for _, m := range parseDependencyList(string(data), "mcps") {
+			if !seen[m] {
+				seen[m] = true
+				result = append(result, m)
+			}
+		}
+	}
+	// Transitive MCPs from resolved skills
+	for _, skill := range c.resolveDependencies(squad) {
+		skillMD := filepath.Join(c.SwatRoot, "blueprints", "skills", skill, "SKILL.md")
+		if data, err := os.ReadFile(skillMD); err == nil {
+			for _, m := range parseDependencyList(string(data), "mcps") {
+				if !seen[m] {
+					seen[m] = true
+					result = append(result, m)
+				}
+			}
+		}
+	}
+	return result
+}
+
+// composeMCPConfig builds .mcp.json from individual MCP config files
+func composeMCPConfig(swatRoot string, mcps []string) string {
+	mcpsDir := filepath.Join(swatRoot, "blueprints", "mcps")
+	servers := make(map[string]string)
+	for _, name := range mcps {
+		path := filepath.Join(mcpsDir, name+".json")
+		if data, err := os.ReadFile(path); err == nil {
+			servers[name] = strings.TrimSpace(string(data))
+		}
+	}
+	if len(servers) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("{\n  \"mcpServers\": {\n")
+	i := 0
+	for name, config := range servers {
+		if i > 0 {
+			sb.WriteString(",\n")
+		}
+		sb.WriteString(fmt.Sprintf("    %q: %s", name, config))
+		i++
+	}
+	sb.WriteString("\n  }\n}\n")
+	return sb.String()
+}
+
+// parseDependencyList extracts a dependency list from frontmatter, e.g. "skills: [a, b]"
+func parseDependencyList(md, field string) []string {
+	if !strings.HasPrefix(md, "---") {
+		return nil
+	}
+	end := strings.Index(md[3:], "\n---")
+	if end < 0 {
+		return nil
+	}
+	fm := md[4 : end+3]
+	// Find "  skills: [...]" or "  mcps: [...]"
+	for _, line := range strings.Split(fm, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, field+":") {
+			val := strings.TrimSpace(strings.TrimPrefix(trimmed, field+":"))
+			val = strings.Trim(val, "[]")
+			if val == "" {
+				return nil
+			}
+			var deps []string
+			for _, d := range strings.Split(val, ",") {
+				d = strings.TrimSpace(d)
+				if d != "" {
+					deps = append(deps, d)
+				}
+			}
+			return deps
+		}
+	}
+	return nil
+}
+
+// assembleAgentsMD replaces placeholders in PROTOCOL.md with manifest sections
+func assembleAgentsMD(manifest, protocol, squadName string) string {
+	domain := extractSection(manifest, "## Domain")
+	boundary := extractSection(manifest, "## Boundary")
+	writeAccess := extractSection(manifest, "## Write Access")
+	playbook := extractSection(manifest, "## Squad Playbook")
+	version := extractFrontmatterField(manifest, "version")
+	if version == "" {
+		version = "1.0.0"
+	}
+
+	result := stripFrontmatter(protocol)
+	result = strings.ReplaceAll(result, "{SQUAD_NAME}", squadName)
+	result = strings.ReplaceAll(result, "{SQUAD_VERSION}", version)
+	result = strings.ReplaceAll(result, "{SQUAD_DOMAIN}", domain)
+	result = strings.ReplaceAll(result, "{SQUAD_BOUNDARY}", boundary)
+	result = strings.ReplaceAll(result, "{SQUAD_WRITE_ACCESS}", writeAccess)
+	result = strings.ReplaceAll(result, "{SQUAD_PLAYBOOK}", playbook)
+	return result
+}
+
+// findOperation locates an operation by ID across all squads
+func (c *Commander) findOperation(opID string) (*Operation, error) {
+	ops, err := c.ListOperations()
+	if err != nil {
+		return nil, err
+	}
+	for _, op := range ops {
+		if op.OperationID == opID {
+			return op, nil
+		}
+	}
+	return nil, fmt.Errorf("operation %s not found", opID)
+}
+
+// ListSquads returns all installed squad blueprints
+func (c *Commander) ListSquads() ([]map[string]string, error) {
+	bpDir := filepath.Join(c.SwatRoot, "blueprints")
+	entries, err := os.ReadDir(filepath.Join(bpDir, "squads"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var squads []map[string]string
+	for _, entry := range entries {
+		if !entry.IsDir() || entry.Name() == "_framework" {
+			continue
+		}
+		info := map[string]string{"name": entry.Name()}
+		manifestPath := filepath.Join(bpDir, "squads", entry.Name(), "MANIFEST.md")
+		if data, err := os.ReadFile(manifestPath); err == nil {
+			if desc := extractFrontmatterField(string(data), "description"); desc != "" {
+				info["description"] = desc
+			}
+		}
+		squads = append(squads, info)
+	}
+	return squads, nil
+}
+
+// --- helpers ---
+
+func extractSection(md, heading string) string {
+	idx := strings.Index(md, heading)
+	if idx < 0 {
+		return ""
+	}
+	content := md[idx+len(heading):]
+	if nextIdx := strings.Index(content, "\n## "); nextIdx >= 0 {
+		content = content[:nextIdx]
+	}
+	return strings.TrimSpace(content)
+}
+
+func extractFrontmatterField(md, field string) string {
+	if !strings.HasPrefix(md, "---") {
+		return ""
+	}
+	end := strings.Index(md[3:], "\n---")
+	if end < 0 {
+		return ""
+	}
+	fm := md[4 : end+3]
+	for _, line := range strings.Split(fm, "\n") {
+		if strings.HasPrefix(line, field+":") {
+			val := strings.TrimSpace(strings.TrimPrefix(line, field+":"))
+			val = strings.Trim(val, "\"")
+			return val
+		}
+	}
+	return ""
+}
+
+func stripFrontmatter(md string) string {
+	if !strings.HasPrefix(md, "---") {
+		return md
+	}
+	end := strings.Index(md[3:], "---")
+	if end < 0 {
+		return md
+	}
+	return strings.TrimLeft(md[end+6:], "\n")
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func fileContains(path, substr string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), substr)
+}
+
+func copyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(src, path)
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, 0755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, 0644)
+	})
 }

--- a/commander/fs.go
+++ b/commander/fs.go
@@ -1,0 +1,41 @@
+package commander
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// fileExists checks if a path exists
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// fileContains checks if a file contains a substring
+func fileContains(path, substr string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), substr)
+}
+
+// copyDir recursively copies a directory tree
+func copyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(src, path)
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, 0755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, 0644)
+	})
+}

--- a/mcp/handlers.go
+++ b/mcp/handlers.go
@@ -220,9 +220,21 @@ func (s *Server) handleCancel(args map[string]interface{}) toolResult {
 }
 
 func (s *Server) handleSquads(args map[string]interface{}) toolResult {
-	// TODO: scan blueprints/squads/ for MANIFEST.md files
+	squads, err := s.Commander.ListSquads()
+	if err != nil {
+		return toolResult{
+			Content: []contentBlock{{Type: "text", Text: fmt.Sprintf("list squads failed: %v", err)}},
+			IsError: true,
+		}
+	}
+	if len(squads) == 0 {
+		return toolResult{
+			Content: []contentBlock{{Type: "text", Text: "no squads installed"}},
+		}
+	}
+	data, _ := json.MarshalIndent(squads, "", "  ")
 	return toolResult{
-		Content: []contentBlock{{Type: "text", Text: "no squads installed yet"}},
+		Content: []contentBlock{{Type: "text", Text: string(data)}},
 	}
 }
 


### PR DESCRIPTION
## Changes

### Operation ID
- 8-hex with `crypto/rand` replacing 4-hex `UnixNano()` modulo — collision-proof

### Blueprints Restructured
- `blueprints/{squads/, skills/, mcps/}` — clean separation
- `OPERATION.md` template at blueprints root
- `ListSquads` iterates `blueprints/squads/` excluding `_framework`

### Recursive Dependency Resolution
- BFS traversal of skill frontmatter `dependencies.skills`
- 3-layer transitive deps verified (skill-a → skill-b → skill-c)

### MCP Composition
- `.mcp.json` auto-generated from `blueprints/mcps/{name}.json`
- Collects MCPs from protocol, manifest, and transitive skill deps

### Skills Path
- Copied to `.github/skills/` (GitHub Copilot convention)
- INTEL.md stays at squad level, NOT copied into operations

### Fire-and-Forget Dispatch
- Dispatch launches immediately via goroutine (no 60s BackgroundLoop wait)
- Removed `handleProcessExit` goroutine
- `Scan()` checks PID liveness + OPERATION.md status + report.html
- Restart recovery handled naturally by Scan (no special recovery code needed)

### Tested
- Research squad with recursive skills (3 layers) + 2 MCPs ✅
- Coding squad end-to-end (countdown.py) ✅