### PR TITLE
feat: add install.sh and core blueprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,113 @@
-# SWAT v2
+# SWAT
 
-AI task orchestration system. Deploy autonomous squads to handle your tasks.
+Deploy your own AI army. SWAT integrates with GitHub Copilot CLI to dispatch autonomous squads that handle your development and operational tasks — orchestrated through [OpenClaw](https://github.com/openclaw/openclaw).
 
-## Architecture
+## 🚀 Installation
 
+```bash
+curl -fsSL https://raw.githubusercontent.com/LangSensei/swat-v2/master/install.sh | bash
 ```
-OpenClaw (HQ) → MCP Bridge Plugin → SWAT Commander (Go) → Squad (Copilot CLI)
+
+This will:
+1. Download the latest release for your platform (Linux/macOS, amd64/arm64)
+2. Install the SWAT binary to `~/.local/bin/`
+3. Set up the OpenClaw bridge plugin at `~/.swat/plugin/`
+4. Install framework blueprints to `~/.swat/blueprints/`
+
+Then register the plugin in your OpenClaw config and restart:
+```json
+{ "plugins": ["~/.swat/plugin"] }
 ```
 
-- **Commander**: Go MCP server — task queue, classification, scheduling, review
-- **Plugin**: OpenClaw bridge — spawns Commander, registers native tools
-- **Squad**: Independent Copilot CLI processes — autonomous task execution
+## 🎮 Usage
 
-## Tools
+SWAT is controlled entirely through OpenClaw — no CLI commands needed. Just chat:
+
+> "Create a Python script that calculates fibonacci numbers"
+
+Or use the tools directly:
 
 | Tool | Description |
 |---|---|
-| swat_dispatch | Dispatch a new task to a squad |
-| swat_status | Get task status + unnotified completions |
-| swat_list | List all operations |
-| swat_cancel | Cancel an operation |
-| swat_squads | List installed squads |
-| swat_schedule | Create a scheduled task |
+| `swat_dispatch` | Dispatch a new task to a squad |
+| `swat_status` | Get task status and unnotified completions |
+| `swat_list` | List all operations |
+| `swat_cancel` | Cancel an operation |
+| `swat_squads` | List installed squads |
+| `swat_schedule` | Create a scheduled task |
 
-## Build
+### Install Squads
+
+Install specialized squads from the [SWAT Marketplace](https://github.com/LangSensei/swat-marketplace):
 
 ```bash
+# Copy squad blueprints to ~/.swat/blueprints/squads/
+# Copy skills to ~/.swat/blueprints/skills/
+# Copy MCP configs to ~/.swat/blueprints/mcps/
+```
+
+## 🧠 Architecture
+
+```
+OpenClaw (HQ) → Bridge Plugin → SWAT Commander (Go) → Squads (Copilot CLI)
+```
+
+1. **OpenClaw (HQ)** — Your primary interface. Chat to plan and assign tasks.
+2. **Commander** — Go MCP server that orchestrates the task lifecycle: dispatch, compose, provision, scan, and review.
+3. **Squads** — Specialized agent configurations. Each squad runs as an independent GitHub Copilot CLI process with its own tools (skills & MCPs), knowledge (intel), and protocol.
+
+### How It Works
+
+1. You dispatch a task (with or without specifying a squad)
+2. Commander composes the workspace — assembles AGENTS.md from protocol + manifest, resolves skill dependencies recursively, generates `.mcp.json`
+3. A Copilot CLI process launches in the operation directory, reads OPERATION.md for the task brief, follows the protocol in AGENTS.md
+4. Commander periodically scans for completion (checks OPERATION.md status + report.html)
+5. Results are reported back to OpenClaw
+
+## 📂 Directory Structure
+
+```
+~/.swat/
+├── blueprints/                    # Templates & marketplace content
+│   ├── OPERATION.md               # Operation template
+│   ├── squads/
+│   │   ├── _framework/            # Core protocol (versioned with binary)
+│   │   │   ├── PROTOCOL.md
+│   │   │   ├── TEMPLATE.md
+│   │   │   └── INTEL.md
+│   │   └── coding/                # Squad blueprints (from marketplace)
+│   │       └── MANIFEST.md
+│   ├── skills/                    # Shared skills (from marketplace)
+│   └── mcps/                      # MCP server configs (from marketplace)
+│
+├── squads/                        # Runtime data
+│   └── coding/
+│       ├── INTEL.md               # Persistent cross-operation experience
+│       └── operations/
+│           └── 20260308-a1b2c3d4/ # Operation workspace
+│               ├── OPERATION.md   # Task brief (single source of truth)
+│               ├── AGENTS.md      # Assembled protocol + manifest
+│               ├── .mcp.json      # Composed MCP config
+│               ├── report.html    # Completion report
+│               └── .github/skills/
+│
+└── plugin/                        # OpenClaw bridge plugin
+```
+
+## 🛠️ Prerequisites
+
+- Linux or macOS
+- [GitHub Copilot CLI](https://githubnext.com/projects/copilot-cli) (`copilot`)
+- Node.js 18+ (for plugin and MCP servers)
+- [OpenClaw](https://github.com/openclaw/openclaw)
+
+## 🔨 Building from Source
+
+```bash
+# Requires Go 1.24+
 go build -o swat .
 ```
 
-## Install Plugin
+## 📄 License
 
-```bash
-openclaw plugins install ./plugin
-```
+MIT

--- a/blueprints/OPERATION.md
+++ b/blueprints/OPERATION.md
@@ -1,0 +1,27 @@
+---
+operation_id:
+squad:
+brief:
+status: in-progress
+source:
+pid: 0
+notified: false
+retry_count: 0
+created_at:
+dispatched_at:
+completed_at:
+failed_at:
+failure_reason:
+summary:
+references: []
+---
+
+# OPERATION
+
+## Task
+
+<!-- Task description injected by Commander -->
+
+## Details
+
+<!-- Optional details -->

--- a/blueprints/_framework/INTEL.md
+++ b/blueprints/_framework/INTEL.md
@@ -1,0 +1,29 @@
+---
+name: intel
+version: "1.0.0"
+description: Squad-level persistent intel template
+---
+
+# {SQUAD_NAME} Squad — Intel
+
+> This file persists across operations. Update it at seal time.
+> - Add a row to the Operation Log for every completed operation
+> - Update Persistent Insights with cross-operation patterns
+> - Keep insights concise and actionable — this is NOT a dump of findings
+
+## Operation Log
+
+> One row per completed operation. Most recent first.
+> Tags are freeform — use short, lowercase labels for fast lookup.
+
+| Operation | Date | Tags | Brief | Outcome |
+|-----------|------|------|-------|---------|
+
+## Persistent Insights
+
+> Cross-operation patterns, recurring issues, and squad-level learnings.
+> Only add insights that would help future operations.
+> Remove or update insights that become stale.
+> Prefix each insight with a hit count `(×N)` — increment N each time a new operation confirms the pattern.
+
+- **(×1) Example insight title:** description of the pattern...

--- a/blueprints/_framework/PROTOCOL.md
+++ b/blueprints/_framework/PROTOCOL.md
@@ -1,0 +1,202 @@
+---
+name: protocol
+version: "1.0.0"
+description: Base squad operation protocol — boot, execution, seal
+dependencies:
+  skills: [planning-with-files, knowledge-with-files]
+  mcps: [playwright]
+---
+
+# {SQUAD_NAME} Squad — Operation Protocol
+
+<!--
+  TEMPLATE INSTRUCTIONS (for Commander):
+  1. Keep YAML frontmatter as-is (preserves protocol version for tracing)
+  2. Replace placeholders — values come from manifest, injected into protocol sections:
+
+     | Placeholder          | Manifest source                  | Protocol location                  |
+     |----------------------|----------------------------------|------------------------------------|
+     | {SQUAD_NAME}         | heading (e.g., "# ECS Squad")    | Captain Protocol intro             |
+     | {SQUAD_VERSION}      | frontmatter `version`            | Captain Protocol intro             |
+     | {SQUAD_DOMAIN}       | ## Domain                        | Operator Protocol → Squad Context  |
+     | {SQUAD_BOUNDARY}     | ## Boundary                      | Operator Protocol → Squad Context  |
+     | {SQUAD_WRITE_ACCESS} | ## Write Access (empty if absent) | Operator Protocol → Permissions    |
+     | {SQUAD_PLAYBOOK}     | ## Squad Playbook                | Operator Protocol → Squad Playbook |
+
+  3. Remove this comment block
+  4. Stamp as AGENTS.md in the operation folder
+-->
+
+<!-- Frozen at dispatch time — do not modify -->
+
+---
+
+## Captain Protocol
+
+You are the **captain** of the **{SQUAD_NAME}** squad (v{SQUAD_VERSION}). You are responsible for the operation described in `OPERATION.md`.
+
+### Procedure
+
+#### Boot
+
+Steps in this section use the **B** prefix.
+
+B1. **Read assignment** — read `OPERATION.md` to understand your assignment
+B2. **Resolve references** — if `OPERATION.md` frontmatter contains a `references` list, fetch full context for each reference (e.g., email thread details, Teams channel context) using any available tool (MCPs, browser, web fetch, etc.) and append the resolved context to the operation body
+B3. **Read protocol** — read the [Operator Protocol](#operator-protocol) section below (squad context, permissions, squad playbook, standards, planning files)
+B4. **Read intel** — read all intel files in the squad folder (resolve the absolute path from your operation folder, two levels up). Only update `INTEL.md` at seal time.
+B5. **Create workspace** — create your working directory: `operators/captain/` (use `mkdir -p`)
+B6. **Initialize planning files** — per the [Planning Files](#planning-files) (knowledge.md is created later at seal time)
+B7. **Playbook prep** — execute any prerequisite steps defined in the Squad Playbook (e.g., repo setup, token acquisition, input resolution, incident intake). Do not begin the main workflow until all prerequisites are done.
+B8. **Enrich `OPERATION.md`** — this is ongoing throughout the operation, not a one-time step. Follow the guidance comments in `OPERATION.md` itself.
+
+#### Execution
+
+Steps in this section use the **E** prefix. Work through your plan phases in `operators/captain/`:
+
+E1. **Execute** — work the current phase, dispatch subagents for independent tracks (see [Subagent Dispatch](#subagent-dispatch))
+   - **Subagents dispatched** → read their `operators/{role}/` directories, synthesize findings into your own `findings.md`, dispatch follow-ups if needed
+E2. **Synthesize** — update `findings.md` with discoveries (follow the 2-Action Rule)
+E3. **Phase Gate** — update `plan.md` and `progress.md` per [Planning Files](#planning-files)
+E4. **Evolve** — add phases, reorder priorities, mark items `[skipped] reason` as findings change scope
+E5. Repeat from E1 for the next phase until all phases are resolved
+
+#### Seal
+
+Steps in this section use the **S** prefix.
+
+S1. **Verify planning files:**
+   a. `plan.md` — all phases marked `complete`, all items resolved (checked off or `[skipped] reason`). If any item is still actionable, go back and execute it.
+   b. `progress.md` — every phase has actions logged with actual actions taken, files created/modified, and results observed. If any section is empty or placeholder, fill it in.
+   c. `findings.md` — all discoveries captured. If any findings from your investigation are missing, add them now.
+S2. **Fill `OPERATION.md`** — write `summary` (2-3 sentences), set `completed_at` timestamp, fill any remaining output schema fields — follow the guidance comments in `OPERATION.md`. Leave `status: in-progress` (do NOT set completed yet).
+S3. **Generate `report.html`** in the operation root (see [Report Generation](#report-generation))
+S4. **Mark completed** — set `status: completed` in `OPERATION.md`
+S5. **Seal knowledge** — see [Knowledge File](#knowledge-file)
+S6. **Update `INTEL.md`** in the squad folder (two levels up from operation folder) — follow the instructions within the file
+S7. **Final verification** — re-read `plan.md`, `progress.md`, and `findings.md`. Confirm the seal phases (report, knowledge, intel) are logged in plan and progress. Fix any gaps.
+S8. **Terminate** — stop the loop. The squad runs in `-p` mode and auto-terminates; the terminal tab closes when the process exits.
+
+### Reference
+
+#### Subagent Dispatch
+
+Dispatch subagents via the Agent tool when the operation has:
+- **Multiple independent tracks** — investigation threads that don't depend on each other (e.g., "check logs" + "review code changes" + "read incident timeline" can run in parallel)
+- **Context pressure** — reading many files, APIs, dashboards, or data sources that would fill your context window before reaching conclusions
+- **Different tool specialization** — subtasks need different tools or system access (e.g., one subagent browses dashboards while another queries Graph API)
+
+Stay hands-on when the investigation is a single thread, the scope is small, or phases share significant context.
+
+**Briefing template** — for each subagent, provide a self-contained briefing with `{role}` and `{mission}` replaced:
+
+```
+You are operator "{role}" on this operation.
+Mission: {mission}
+
+Your working directory is: operators/{role}/
+ALL your files MUST go in this directory.
+
+Read OPERATION.md for the full operation context.
+
+Execution:
+  1. Create operators/{role}/ directory
+  2. Initialize planning files per the planning-with-files skill and Planning Files section
+  3. Work through your plan phases — update findings.md, plan.md, and progress.md at each phase gate
+  4. When all phases are resolved, verify your planning files are complete and accurate
+```
+
+**Parallel dispatch** — launch subagents with independent missions concurrently (multiple Agent calls in one message). Subagents load AGENTS.md automatically.
+
+**Playwright constraint** — Playwright MCP controls a single shared browser instance. Assign browser-dependent tasks to one subagent at a time — do not dispatch multiple subagents that need Playwright concurrently.
+
+**Reading results** — after subagent completion, read their `operators/{role}/` files (plan.md, progress.md, findings.md). Synthesize findings into your own `findings.md`. Dispatch follow-up subagents if gaps remain.
+
+#### Report Generation
+
+Generate `report.html` in the operation root. Pull content from `OPERATION.md` and all `operators/*/` directories (plan.md, findings.md, progress.md, knowledge.md where present).
+
+Requirements:
+- **Single self-contained HTML file** — all CSS inlined, no external dependencies
+- **Responsive** — must be readable on both mobile and desktop (include `<meta name="viewport">`)
+- **Comprehensive** — include all details, not just a summary
+- **Polished** — this is the deliverable, not a raw dump of markdown files. Structure the content for a reader who has no context
+
+#### Knowledge File
+
+Copy the template **exactly**:
+- `.github/skills/knowledge-with-files/templates/knowledge.md` → `operators/captain/knowledge.md`
+
+Fill in all Metadata fields (Date, ID, Status, Authors, Tags, Summary). **Keep all template sections.** Follow `.github/skills/knowledge-with-files/SKILL.md` for what to distill.
+
+---
+
+## Operator Protocol
+
+**This section applies to every operator — captain and subagents alike.**
+
+### Squad Context
+
+**Squad domain:** {SQUAD_DOMAIN}
+**Squad boundary:** {SQUAD_BOUNDARY}
+
+### Permissions
+
+You have read access to all files on this machine. You may ONLY write to:
+1. Your operator directory: `operators/{role}/`
+2. `temp/` — temporary working artifacts (zips, staged files, downloads, script output). Clean up when done.
+{SQUAD_WRITE_ACCESS}
+
+Do NOT write to any other location.
+
+### Squad Playbook
+
+{SQUAD_PLAYBOOK}
+
+### Standards
+
+You are fully autonomous. **There is no human in the loop.** Do not ask for guidance, clarification, or confirmation from humans — make decisions and act.
+
+**Be thorough:**
+- Use every available tool (MCPs, web search, browser) to gather information
+- Follow every lead — if a finding references another resource, go read it
+- Cross-reference multiple sources; don't rely on a single data point
+- If an API or tool gives you a pointer (URL, ID, path), follow it
+- Dig until you hit bedrock — surface-level summaries are not acceptable
+
+**Be exhaustive:**
+- For incidents: read the full timeline, all discussion entries, related incidents, mitigation history, and linked resources
+- For code changes: read the actual diff, understand what changed and why, check deployment status
+- For metrics: look at dashboards, compare before/after, quantify impact with numbers
+- For action items: verify current status — are they done or still pending?
+
+**Be actionable:**
+- Every finding should answer "so what?" — what does this mean, what should happen next
+- Provide concrete recommendations, not vague observations
+- If something is blocked, identify who/what is blocking it and what would unblock it
+
+**File encoding:** Always use UTF-8 when reading or writing files. Prefer built-in tools (view, create, edit) over inline scripts for file operations.
+
+**Timestamps:** always use UTC in ISO 8601 format (`YYYY-MM-DDTHH:MM:SSZ`). Never use local time.
+
+**Shell escaping:** `$` in double-quoted bash strings is interpreted by bash, not passed through. Use single quotes to protect `$`: single-quote URLs containing `$filter`/`$top`, and use `pwsh -Command '...'` (single-quoted) for inline PowerShell so `$variables` pass through to PowerShell intact.
+
+### Planning Files
+
+Copy these templates **exactly** into your operator directory (`operators/{role}/`):
+- `.github/skills/planning-with-files/templates/plan.md` → `operators/{role}/plan.md`
+- `.github/skills/planning-with-files/templates/findings.md` → `operators/{role}/findings.md`
+- `.github/skills/planning-with-files/templates/progress.md` → `operators/{role}/progress.md`
+
+Fill in the placeholders. **Keep all template sections and tables** — do not remove or restructure them. Follow `.github/skills/planning-with-files/SKILL.md` for the full rules on when to update each file.
+
+**Critical — The 2-Action Rule:** After every 2 search/browse/view operations, IMMEDIATELY save key findings to `findings.md`. Do not wait. Multimodal and browser content is lost if not written to disk promptly.
+
+**Critical — Phase Gate:** Before starting the next phase, you MUST complete ALL of these steps. Do NOT proceed to the next phase until every step is done:
+1. Check off completed items in `plan.md`
+2. Update the phase status from `in_progress` → `complete`
+3. Update `Current Phase` to the next phase
+4. Save any new discoveries to `findings.md`
+5. Update `progress.md` — log every action taken, every file created/modified, and every command result in the current phase's section. Update the 5-Question Reboot Check to reflect current state.
+6. **Verify:** Re-read `progress.md` and confirm the current phase section is filled in — not empty, not placeholder. If it is, fix it before moving on.
+

--- a/blueprints/_framework/TEMPLATE.md
+++ b/blueprints/_framework/TEMPLATE.md
@@ -1,0 +1,30 @@
+---
+name: {squad-name}                 # kebab-case identifier, matches folder name
+version: "1.0.0"
+description: {one-liner description}
+dependencies:                      # omit block if no dependencies
+  skills: [{skill-names}]
+  mcps: [{mcp-names}]
+---
+
+# {Squad Name} Squad               <!-- display name, can differ from frontmatter name -->
+
+## Domain
+{Detailed scope — what operations, services, or codebases this squad handles.}
+
+## Boundary
+- {What the squad DOES — list capabilities}
+- Does NOT {what the squad does NOT do — explicit exclusions}
+
+## Write Access
+- {paths the squad can write to, or "(none — all interactions via API)" if API-only}
+
+## Squad Playbook
+{Domain knowledge, API endpoints, workflows, operational guidance. Use ### subsections to organize content — do not create additional ## sections.}
+
+## Output Schema
+Captain must fill these frontmatter fields in `OPERATION.md` during the operation:
+```yaml
+{field}: # {description}
+action_items: [] # Follow-up steps
+```

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SWAT v2 Installer
+# Usage: curl -fsSL https://raw.githubusercontent.com/LangSensei/swat-v2/master/install.sh | bash
+
+REPO="https://github.com/LangSensei/swat-v2.git"
+MARKETPLACE="https://github.com/LangSensei/swat-marketplace.git"
+SWAT_HOME="$HOME/.swat"
+INSTALL_DIR="$SWAT_HOME/core"
+BIN_DIR="$HOME/.local/bin"
+
+info()  { echo -e "\033[0;36m[swat]\033[0m $*"; }
+ok()    { echo -e "\033[0;32m[swat]\033[0m $*"; }
+err()   { echo -e "\033[0;31m[swat]\033[0m $*" >&2; }
+die()   { err "$@"; exit 1; }
+
+# --- Prerequisites ---
+
+check_prereqs() {
+    local missing=()
+
+    command -v go   >/dev/null 2>&1 || missing+=("go")
+    command -v node >/dev/null 2>&1 || missing+=("node")
+    command -v npm  >/dev/null 2>&1 || missing+=("npm")
+    command -v git  >/dev/null 2>&1 || missing+=("git")
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        die "Missing prerequisites: ${missing[*]}"
+    fi
+
+    # Copilot CLI is optional at install time, required at runtime
+    if ! command -v copilot >/dev/null 2>&1; then
+        info "Warning: GitHub Copilot CLI not found. Install it before dispatching tasks."
+        info "  npm install -g @githubnext/github-copilot-cli"
+    fi
+}
+
+# --- Clone / Update Source ---
+
+fetch_source() {
+    if [[ -d "$INSTALL_DIR/.git" ]]; then
+        info "Updating SWAT core..."
+        git -C "$INSTALL_DIR" pull --quiet
+    else
+        info "Cloning SWAT core..."
+        mkdir -p "$INSTALL_DIR"
+        git clone --quiet "$REPO" "$INSTALL_DIR"
+    fi
+}
+
+# --- Build Binary ---
+
+build_binary() {
+    info "Building SWAT binary..."
+    cd "$INSTALL_DIR"
+    go build -o swat .
+    mkdir -p "$BIN_DIR"
+    cp swat "$BIN_DIR/swat"
+    chmod +x "$BIN_DIR/swat"
+    ok "Binary installed to $BIN_DIR/swat"
+}
+
+# --- Install Plugin Dependencies ---
+
+install_plugin() {
+    info "Installing plugin dependencies..."
+    cd "$INSTALL_DIR/plugin"
+    npm install --quiet 2>/dev/null
+    ok "Plugin ready"
+}
+
+# --- Set Up Blueprints ---
+
+setup_blueprints() {
+    local bp="$SWAT_HOME/blueprints"
+    mkdir -p "$bp/squads/_framework"
+
+    # Core framework files (from swat-v2 repo)
+    info "Installing framework blueprints..."
+    cp "$INSTALL_DIR/blueprints/OPERATION.md" "$bp/"
+    cp "$INSTALL_DIR/blueprints/_framework/"* "$bp/squads/_framework/"
+
+    # Marketplace content (squads, skills, mcps)
+    local mp_tmp="$SWAT_HOME/.marketplace-tmp"
+    if [[ -d "$mp_tmp/.git" ]]; then
+        git -C "$mp_tmp" pull --quiet
+    else
+        info "Fetching marketplace blueprints..."
+        git clone --quiet "$MARKETPLACE" "$mp_tmp"
+    fi
+
+    # Copy marketplace content into blueprints
+    for dir in squads skills mcps; do
+        if [[ -d "$mp_tmp/$dir" ]]; then
+            mkdir -p "$bp/$dir"
+            cp -r "$mp_tmp/$dir/"* "$bp/$dir/" 2>/dev/null || true
+        fi
+    done
+
+    ok "Blueprints installed"
+}
+
+# --- Set Up Runtime Directory ---
+
+setup_runtime() {
+    mkdir -p "$SWAT_HOME/squads"
+}
+
+# --- Register OpenClaw Plugin ---
+
+register_plugin() {
+    local oc_config="$HOME/.openclaw/openclaw.json"
+    if [[ -f "$oc_config" ]]; then
+        info "OpenClaw detected. Register the SWAT plugin by adding to your config:"
+        echo ""
+        echo "  \"plugins\": [\"$INSTALL_DIR/plugin\"]"
+        echo ""
+        info "Then restart OpenClaw: openclaw gateway restart"
+    else
+        info "OpenClaw not detected. Install OpenClaw and add the plugin path:"
+        echo "  $INSTALL_DIR/plugin"
+    fi
+}
+
+# --- PATH Check ---
+
+check_path() {
+    if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then
+        info "Add to your shell profile:"
+        echo "  export PATH=\"$BIN_DIR:\$PATH\""
+    fi
+}
+
+# --- Main ---
+
+main() {
+    echo ""
+    info "Installing SWAT v2..."
+    echo ""
+
+    check_prereqs
+    fetch_source
+    build_binary
+    install_plugin
+    setup_blueprints
+    setup_runtime
+    register_plugin
+    check_path
+
+    echo ""
+    ok "SWAT v2 installed successfully! 🚀"
+    echo ""
+}
+
+main "$@"

--- a/install.sh
+++ b/install.sh
@@ -4,9 +4,8 @@ set -euo pipefail
 # SWAT v2 Installer
 # Usage: curl -fsSL https://raw.githubusercontent.com/LangSensei/swat-v2/master/install.sh | bash
 
-REPO="https://github.com/LangSensei/swat-v2.git"
+REPO="LangSensei/swat-v2"
 SWAT_HOME="$HOME/.swat"
-INSTALL_DIR="$SWAT_HOME/core"
 BIN_DIR="$HOME/.local/bin"
 
 info()  { echo -e "\033[0;36m[swat]\033[0m $*"; }
@@ -14,106 +13,147 @@ ok()    { echo -e "\033[0;32m[swat]\033[0m $*"; }
 err()   { echo -e "\033[0;31m[swat]\033[0m $*" >&2; }
 die()   { err "$@"; exit 1; }
 
+# --- Detect Platform ---
+
+detect_platform() {
+    local os arch
+    os=$(uname -s | tr '[:upper:]' '[:lower:]')
+    arch=$(uname -m)
+
+    case "$os" in
+        linux)  OS="linux" ;;
+        darwin) OS="darwin" ;;
+        *)      die "Unsupported OS: $os" ;;
+    esac
+
+    case "$arch" in
+        x86_64|amd64)  ARCH="amd64" ;;
+        aarch64|arm64) ARCH="arm64" ;;
+        *)             die "Unsupported architecture: $arch" ;;
+    esac
+
+    PLATFORM="${OS}-${ARCH}"
+    info "Detected platform: $PLATFORM"
+}
+
 # --- Prerequisites ---
 
 check_prereqs() {
     local missing=()
-
-    command -v go   >/dev/null 2>&1 || missing+=("go")
+    command -v curl >/dev/null 2>&1 || command -v wget >/dev/null 2>&1 || missing+=("curl or wget")
+    command -v tar  >/dev/null 2>&1 || missing+=("tar")
     command -v node >/dev/null 2>&1 || missing+=("node")
     command -v npm  >/dev/null 2>&1 || missing+=("npm")
-    command -v git  >/dev/null 2>&1 || missing+=("git")
 
     if [[ ${#missing[@]} -gt 0 ]]; then
         die "Missing prerequisites: ${missing[*]}"
     fi
 
-    # Copilot CLI is optional at install time, required at runtime
     if ! command -v copilot >/dev/null 2>&1; then
-        info "Warning: GitHub Copilot CLI not found. Install it before dispatching tasks."
+        info "Warning: GitHub Copilot CLI not found. Required for running squads."
         info "  npm install -g @githubnext/github-copilot-cli"
     fi
 }
 
-# --- Clone / Update Source ---
+# --- Download & Extract ---
 
-fetch_source() {
-    if [[ -d "$INSTALL_DIR/.git" ]]; then
-        info "Updating SWAT core..."
-        git -C "$INSTALL_DIR" pull --quiet
+download() {
+    local url="$1" dest="$2"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL -o "$dest" "$url"
     else
-        info "Cloning SWAT core..."
-        mkdir -p "$INSTALL_DIR"
-        git clone --quiet "$REPO" "$INSTALL_DIR"
+        wget -qO "$dest" "$url"
     fi
 }
 
-# --- Build Binary ---
+fetch_release() {
+    # Get latest release tag
+    local api_url="https://api.github.com/repos/$REPO/releases/latest"
+    local tag
 
-build_binary() {
-    info "Building SWAT binary..."
-    cd "$INSTALL_DIR"
-    go build -o swat .
+    if command -v curl >/dev/null 2>&1; then
+        tag=$(curl -fsSL "$api_url" | grep '"tag_name"' | head -1 | sed 's/.*: "\(.*\)".*/\1/')
+    else
+        tag=$(wget -qO- "$api_url" | grep '"tag_name"' | head -1 | sed 's/.*: "\(.*\)".*/\1/')
+    fi
+
+    if [[ -z "$tag" ]]; then
+        die "Failed to fetch latest release"
+    fi
+
+    info "Latest release: $tag"
+
+    local tarball="swat-${tag}-${PLATFORM}.tar.gz"
+    local dl_url="https://github.com/$REPO/releases/download/${tag}/${tarball}"
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+
+    info "Downloading $tarball..."
+    download "$dl_url" "$tmp_dir/$tarball"
+
+    info "Extracting..."
+    tar -xzf "$tmp_dir/$tarball" -C "$tmp_dir"
+
+    EXTRACT_DIR="$tmp_dir"
+}
+
+# --- Install ---
+
+install_binary() {
     mkdir -p "$BIN_DIR"
-    cp swat "$BIN_DIR/swat"
+    cp "$EXTRACT_DIR/swat" "$BIN_DIR/swat"
     chmod +x "$BIN_DIR/swat"
     ok "Binary installed to $BIN_DIR/swat"
 }
 
-# --- Install Plugin Dependencies ---
-
 install_plugin() {
+    local dest="$SWAT_HOME/plugin"
+    rm -rf "$dest"
+    mkdir -p "$dest"
+    cp -r "$EXTRACT_DIR/plugin/"* "$dest/"
+
     info "Installing plugin dependencies..."
-    cd "$INSTALL_DIR/plugin"
-    npm install --quiet 2>/dev/null
-    ok "Plugin ready"
+    cd "$dest" && npm install --quiet 2>/dev/null
+    ok "Plugin installed to $dest"
 }
 
-# --- Set Up Blueprints ---
-
-setup_blueprints() {
+install_blueprints() {
     local bp="$SWAT_HOME/blueprints"
     mkdir -p "$bp/squads/_framework" "$bp/skills" "$bp/mcps"
 
-    # Core framework files (from swat-v2 repo)
-    info "Installing framework blueprints..."
-    cp "$INSTALL_DIR/blueprints/OPERATION.md" "$bp/"
-    cp "$INSTALL_DIR/blueprints/_framework/"* "$bp/squads/_framework/"
+    cp "$EXTRACT_DIR/blueprints/OPERATION.md" "$bp/"
+    cp "$EXTRACT_DIR/blueprints/_framework/"* "$bp/squads/_framework/"
 
-    ok "Blueprints installed"
+    ok "Framework blueprints installed"
     info "Install squads/skills/mcps from the marketplace:"
     echo "  https://github.com/LangSensei/swat-marketplace"
 }
-
-# --- Set Up Runtime Directory ---
 
 setup_runtime() {
     mkdir -p "$SWAT_HOME/squads"
 }
 
-# --- Register OpenClaw Plugin ---
+# --- Post-Install ---
 
-register_plugin() {
-    local oc_config="$HOME/.openclaw/openclaw.json"
-    if [[ -f "$oc_config" ]]; then
-        info "OpenClaw detected. Register the SWAT plugin by adding to your config:"
-        echo ""
-        echo "  \"plugins\": [\"$INSTALL_DIR/plugin\"]"
-        echo ""
-        info "Then restart OpenClaw: openclaw gateway restart"
-    else
-        info "OpenClaw not detected. Install OpenClaw and add the plugin path:"
-        echo "  $INSTALL_DIR/plugin"
-    fi
-}
-
-# --- PATH Check ---
-
-check_path() {
+post_install() {
+    # PATH check
     if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then
         info "Add to your shell profile:"
         echo "  export PATH=\"$BIN_DIR:\$PATH\""
+        echo ""
     fi
+
+    # OpenClaw plugin registration
+    info "Register the SWAT plugin in your OpenClaw config:"
+    echo "  \"plugins\": [\"$SWAT_HOME/plugin\"]"
+    echo ""
+    info "Then restart OpenClaw: openclaw gateway restart"
+}
+
+# --- Cleanup ---
+
+cleanup() {
+    rm -rf "$EXTRACT_DIR"
 }
 
 # --- Main ---
@@ -123,14 +163,15 @@ main() {
     info "Installing SWAT v2..."
     echo ""
 
+    detect_platform
     check_prereqs
-    fetch_source
-    build_binary
+    fetch_release
+    install_binary
     install_plugin
-    setup_blueprints
+    install_blueprints
     setup_runtime
-    register_plugin
-    check_path
+    post_install
+    cleanup
 
     echo ""
     ok "SWAT v2 installed successfully! 🚀"

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,6 @@ set -euo pipefail
 # Usage: curl -fsSL https://raw.githubusercontent.com/LangSensei/swat-v2/master/install.sh | bash
 
 REPO="https://github.com/LangSensei/swat-v2.git"
-MARKETPLACE="https://github.com/LangSensei/swat-marketplace.git"
 SWAT_HOME="$HOME/.swat"
 INSTALL_DIR="$SWAT_HOME/core"
 BIN_DIR="$HOME/.local/bin"
@@ -74,31 +73,16 @@ install_plugin() {
 
 setup_blueprints() {
     local bp="$SWAT_HOME/blueprints"
-    mkdir -p "$bp/squads/_framework"
+    mkdir -p "$bp/squads/_framework" "$bp/skills" "$bp/mcps"
 
     # Core framework files (from swat-v2 repo)
     info "Installing framework blueprints..."
     cp "$INSTALL_DIR/blueprints/OPERATION.md" "$bp/"
     cp "$INSTALL_DIR/blueprints/_framework/"* "$bp/squads/_framework/"
 
-    # Marketplace content (squads, skills, mcps)
-    local mp_tmp="$SWAT_HOME/.marketplace-tmp"
-    if [[ -d "$mp_tmp/.git" ]]; then
-        git -C "$mp_tmp" pull --quiet
-    else
-        info "Fetching marketplace blueprints..."
-        git clone --quiet "$MARKETPLACE" "$mp_tmp"
-    fi
-
-    # Copy marketplace content into blueprints
-    for dir in squads skills mcps; do
-        if [[ -d "$mp_tmp/$dir" ]]; then
-            mkdir -p "$bp/$dir"
-            cp -r "$mp_tmp/$dir/"* "$bp/$dir/" 2>/dev/null || true
-        fi
-    done
-
     ok "Blueprints installed"
+    info "Install squads/skills/mcps from the marketplace:"
+    echo "  https://github.com/LangSensei/swat-marketplace"
 }
 
 # --- Set Up Runtime Directory ---


### PR DESCRIPTION
## Changes

### install.sh
One-line installer:
```bash
curl -fsSL https://raw.githubusercontent.com/LangSensei/swat-v2/master/install.sh | bash
```

Steps:
1. Check prerequisites (go, node, npm, git)
2. Clone swat-v2 → `~/.swat/core/`
3. `go build` → binary at `~/.local/bin/swat`
4. `npm install` for plugin dependencies
5. Copy framework blueprints from core repo
6. Clone marketplace content (squads, skills, mcps)
7. Print OpenClaw plugin registration instructions

### Core Blueprints
Moved into the swat-v2 repo (framework = contract with Commander):
- `blueprints/OPERATION.md` — operation template
- `blueprints/_framework/PROTOCOL.md` — squad protocol (Captain + Operator)
- `blueprints/_framework/TEMPLATE.md` — MANIFEST template
- `blueprints/_framework/INTEL.md` — INTEL template

### Why
- Framework files must version-lock with the binary
- Marketplace content (squads/skills/mcps) stays in swat-marketplace