### PR TITLE
feat: add OpenClaw skill for SWAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,11 @@ jobs:
           PLATFORM="${{ matrix.goos }}-${{ matrix.goarch }}"
           TARBALL="swat-${TAG}-${PLATFORM}.tar.gz"
 
-          mkdir -p staging/plugin staging/blueprints/_framework
+          mkdir -p staging/plugin staging/skill staging/blueprints/_framework
 
           cp swat staging/
           cp plugin/index.ts plugin/package.json plugin/openclaw.plugin.json staging/plugin/
+          cp skill/SKILL.md staging/skill/
           cp blueprints/OPERATION.md staging/blueprints/
           cp blueprints/_framework/* staging/blueprints/_framework/
 

--- a/install.sh
+++ b/install.sh
@@ -117,6 +117,26 @@ install_plugin() {
     ok "Plugin installed to $dest"
 }
 
+install_skill() {
+    local oc_skills
+    # Find OpenClaw skills directory
+    for dir in "$HOME/.npm-global/lib/node_modules/openclaw/skills" "/usr/local/lib/node_modules/openclaw/skills" "/usr/lib/node_modules/openclaw/skills"; do
+        if [[ -d "$dir" ]]; then
+            oc_skills="$dir"
+            break
+        fi
+    done
+
+    if [[ -z "$oc_skills" ]]; then
+        info "OpenClaw skills directory not found. Manually copy skill/SKILL.md to your OpenClaw skills dir."
+        return
+    fi
+
+    mkdir -p "$oc_skills/swat"
+    cp "$EXTRACT_DIR/skill/SKILL.md" "$oc_skills/swat/"
+    ok "Skill installed to $oc_skills/swat/"
+}
+
 install_blueprints() {
     local bp="$SWAT_HOME/blueprints"
     mkdir -p "$bp/squads/_framework" "$bp/skills" "$bp/mcps"
@@ -168,6 +188,7 @@ main() {
     fetch_release
     install_binary
     install_plugin
+    install_skill
     install_blueprints
     setup_runtime
     post_install

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,0 +1,63 @@
+# SWAT - Autonomous Squad Orchestration
+
+SWAT dispatches tasks to autonomous AI squads powered by GitHub Copilot CLI. Each squad is a specialist (coding, research, etc.) that works independently in the background.
+
+## When to Use
+
+- User wants a task done autonomously in the background
+- Tasks that benefit from a specialist agent (coding, research, writing)
+- Multiple tasks that can run in parallel
+- User says things like "do this for me", "handle this", "work on this in the background"
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `swat_dispatch` | Send a task to a squad |
+| `swat_status` | Check for completions and unnotified results |
+| `swat_squads` | List available squads |
+| `swat_list` | List all operations with status |
+| `swat_cancel` | Cancel a running operation |
+| `swat_schedule` | Create a scheduled/recurring task |
+
+## How to Use
+
+### 1. Check available squads
+Call `swat_squads` to see what's installed. Each squad has a domain (e.g., coding, research).
+
+### 2. Dispatch a task
+```
+swat_dispatch:
+  brief: "Short task description" (required)
+  squad: "squad-name" (required — must match an installed squad)
+  details: "Additional context, requirements, links" (optional)
+```
+
+### 3. Monitor progress
+- `swat_status` — Returns unnotified completions. Call after dispatch or periodically.
+- `swat_list` — Shows all operations (queued, active, completed, failed).
+
+### 4. Report results
+When `swat_status` returns a completed operation, summarize the result to the user.
+
+### 5. Cancel if needed
+```
+swat_cancel:
+  operation_id: "20260308-a1b2c3d4"
+```
+
+## Typical Flow
+
+1. User requests a task → check `swat_squads` if unsure which squad
+2. `swat_dispatch` with brief + squad → returns operation ID immediately
+3. Tell the user the task is dispatched and which squad is handling it
+4. Later, `swat_status` picks up the completion → summarize to user
+
+## Important Notes
+
+- **Dispatch is async** — the squad works in the background, don't wait for it
+- **Squad selection matters** — pick the squad whose domain matches the task
+- **If no squad fits** — tell the user; don't dispatch to a random squad
+- **Multiple operations** can run concurrently across different squads
+- **Results** are in OPERATION.md when status becomes `completed`
+- **Failed operations** include a failure reason in the status response


### PR DESCRIPTION
## Changes

### skill/SKILL.md
Teaches OpenClaw when and how to use SWAT tools:
- When to trigger SWAT (background tasks, autonomous work)
- Tool usage guide (dispatch → monitor → report)
- Typical flow and important notes

### install.sh
Auto-detects OpenClaw skills directory and copies skill there.

### Manual step needed
Update `release.yml` to include `skill/` in the tarball:
```yaml
mkdir -p staging/plugin staging/skill staging/blueprints/_framework
cp skill/SKILL.md staging/skill/
```
(Can't push workflow changes due to OAuth scope)