### PR TITLE
feat: swat_install/swat_uninstall + plugin path fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SWAT
 
-Deploy your own AI army. SWAT integrates with GitHub Copilot CLI to dispatch autonomous squads that handle your development and operational tasks — orchestrated through [OpenClaw](https://github.com/openclaw/openclaw).
+Deploy your own AI army. SWAT dispatches autonomous squads powered by GitHub Copilot CLI — orchestrated through [OpenClaw](https://github.com/openclaw/openclaw).
 
 ## 🚀 Installation
 
@@ -13,82 +13,98 @@ This will:
 2. Install the SWAT binary to `~/.local/bin/`
 3. Set up the OpenClaw bridge plugin at `~/.swat/plugin/`
 4. Install framework blueprints to `~/.swat/blueprints/`
+5. Auto-register the plugin in your OpenClaw config
 
-Then register the plugin in your OpenClaw config and restart:
-```json
-{ "plugins": ["~/.swat/plugin"] }
+Then restart OpenClaw and install a squad:
 ```
+swat_browse    → see available squads
+swat_install   → install one
+swat_dispatch  → start a task
+```
+
+## 🗑️ Uninstallation
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/LangSensei/swat-v2/master/uninstall.sh | bash
+```
+
+Add `--purge` to also remove runtime data (operation history, intel).
 
 ## 🎮 Usage
 
-SWAT is controlled entirely through OpenClaw — no CLI commands needed. Just chat:
+SWAT is controlled entirely through OpenClaw — no CLI needed. Just chat:
 
-> "Create a Python script that calculates fibonacci numbers"
+> "Analyze 贵州茅台's recent stock performance"
 
 Or use the tools directly:
 
 | Tool | Description |
 |---|---|
-| `swat_dispatch` | Dispatch a new task to a squad |
-| `swat_status` | Get task status and unnotified completions |
+| `swat_dispatch` | Dispatch a task to a squad |
+| `swat_status` | Check for completions |
 | `swat_list` | List all operations |
 | `swat_cancel` | Cancel an operation |
 | `swat_squads` | List installed squads |
 | `swat_schedule` | Create a scheduled task |
+| `swat_browse` | Browse squads in the marketplace |
+| `swat_install` | Install a squad + dependencies |
+| `swat_uninstall` | Uninstall a squad + clean orphans |
 
-### Install Squads
+### Marketplace
 
 Install specialized squads from the [SWAT Marketplace](https://github.com/LangSensei/swat-marketplace):
 
-```bash
-# Copy squad blueprints to ~/.swat/blueprints/squads/
-# Copy skills to ~/.swat/blueprints/skills/
-# Copy MCP configs to ~/.swat/blueprints/mcps/
 ```
+swat_browse                    → list available squads
+swat_install(squad: "coding")  → install squad + resolve dependencies
+swat_uninstall(squad: "coding") → remove squad + clean orphaned deps
+```
+
+No `git clone` needed — SWAT fetches directly from GitHub API.
 
 ## 🧠 Architecture
 
 ```
-OpenClaw (HQ) → Bridge Plugin → SWAT Commander (Go) → Squads (Copilot CLI)
+OpenClaw (HQ) → Bridge Plugin → SWAT Commander (Go MCP) → Squads (Copilot CLI)
 ```
 
-1. **OpenClaw (HQ)** — Your primary interface. Chat to plan and assign tasks.
-2. **Commander** — Go MCP server that orchestrates the task lifecycle: dispatch, compose, provision, scan, and review.
-3. **Squads** — Specialized agent configurations. Each squad runs as an independent GitHub Copilot CLI process with its own tools (skills & MCPs), knowledge (intel), and protocol.
+1. **OpenClaw** — Your interface. Chat to dispatch and monitor tasks.
+2. **Commander** — Go MCP server. Handles dispatch, workspace composition, dependency resolution, and completion scanning.
+3. **Squads** — Specialist agents. Each runs as an independent Copilot CLI process with its own skills, MCP tools, and protocol.
 
 ### How It Works
 
-1. You dispatch a task (with or without specifying a squad)
-2. Commander composes the workspace — assembles AGENTS.md from protocol + manifest, resolves skill dependencies recursively, generates `.mcp.json`
-3. A Copilot CLI process launches in the operation directory, reads OPERATION.md for the task brief, follows the protocol in AGENTS.md
-4. Commander periodically scans for completion (checks OPERATION.md status + report.html)
-5. Results are reported back to OpenClaw
+1. You dispatch a task (specify squad or let Commander classify)
+2. Commander composes the workspace — assembles AGENTS.md, resolves skill dependencies (BFS), generates `.mcp.json`
+3. Copilot CLI launches in the operation directory, reads OPERATION.md + AGENTS.md
+4. Commander's background loop scans for completion (OPERATION.md status + report.html)
+5. Results surface through `swat_status`
 
 ## 📂 Directory Structure
 
 ```
 ~/.swat/
-├── blueprints/                    # Templates & marketplace content
+├── blueprints/                    # Templates & installed content
 │   ├── OPERATION.md               # Operation template
 │   ├── squads/
 │   │   ├── _framework/            # Core protocol (versioned with binary)
 │   │   │   ├── PROTOCOL.md
 │   │   │   ├── TEMPLATE.md
 │   │   │   └── INTEL.md
-│   │   └── coding/                # Squad blueprints (from marketplace)
+│   │   └── <squad>/               # Squad blueprints
 │   │       └── MANIFEST.md
-│   ├── skills/                    # Shared skills (from marketplace)
-│   └── mcps/                      # MCP server configs (from marketplace)
+│   ├── skills/                    # Shared skills
+│   └── mcps/                      # MCP server configs
 │
 ├── squads/                        # Runtime data
-│   └── coding/
-│       ├── INTEL.md               # Persistent cross-operation experience
+│   └── <squad>/
+│       ├── INTEL.md               # Persistent cross-operation knowledge
 │       └── operations/
-│           └── 20260308-a1b2c3d4/ # Operation workspace
-│               ├── OPERATION.md   # Task brief (single source of truth)
-│               ├── AGENTS.md      # Assembled protocol + manifest
-│               ├── .mcp.json      # Composed MCP config
-│               ├── report.html    # Completion report
+│           └── <id>/              # Operation workspace
+│               ├── OPERATION.md
+│               ├── AGENTS.md
+│               ├── .mcp.json
+│               ├── report.html
 │               └── .github/skills/
 │
 └── plugin/                        # OpenClaw bridge plugin
@@ -98,14 +114,13 @@ OpenClaw (HQ) → Bridge Plugin → SWAT Commander (Go) → Squads (Copilot CLI)
 
 - Linux or macOS
 - [GitHub Copilot CLI](https://githubnext.com/projects/copilot-cli) (`copilot`)
-- Node.js 18+ (for plugin and MCP servers)
+- Node.js 18+
 - [OpenClaw](https://github.com/openclaw/openclaw)
 
 ## 🔨 Building from Source
 
 ```bash
-# Requires Go 1.24+
-go build -o swat .
+go build -o swat .   # Go 1.24+
 ```
 
 ## 📄 License

--- a/commander/fs.go
+++ b/commander/fs.go
@@ -2,6 +2,7 @@ package commander
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -10,6 +11,12 @@ import (
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// dirExists checks if a path exists and is a directory
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
 }
 
 // fileContains checks if a file contains a substring
@@ -38,4 +45,9 @@ func copyDir(src, dst string) error {
 		}
 		return os.WriteFile(target, data, 0644)
 	})
+}
+
+// execCommand creates an exec.Cmd
+func execCommand(name string, args ...string) *exec.Cmd {
+	return exec.Command(name, args...)
 }

--- a/commander/marketplace.go
+++ b/commander/marketplace.go
@@ -1,0 +1,267 @@
+package commander
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const marketplaceAPI = "https://api.github.com/repos/LangSensei/swat-marketplace"
+
+// BrowseResult represents a squad available in the marketplace
+type BrowseResult struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Installed   bool   `json:"installed"`
+}
+
+// Browse lists all squads available in the marketplace
+func (c *Commander) Browse() ([]BrowseResult, error) {
+	// List squads/ directory via GitHub API
+	entries, err := ghListDir("squads")
+	if err != nil {
+		return nil, fmt.Errorf("list marketplace squads: %w", err)
+	}
+
+	var results []BrowseResult
+	for _, e := range entries {
+		name := e.Name
+		if e.Type != "dir" || name == "_framework" {
+			continue
+		}
+		// Fetch MANIFEST.md to get description
+		desc := ""
+		data, err := ghGetFile("squads/" + name + "/MANIFEST.md")
+		if err == nil {
+			desc = extractFrontmatterField(string(data), "description")
+		}
+		installed := dirExists(filepath.Join(c.SwatRoot, "blueprints", "squads", name))
+		results = append(results, BrowseResult{
+			Name:        name,
+			Description: desc,
+			Installed:   installed,
+		})
+	}
+	return results, nil
+}
+
+// Install fetches a squad from the marketplace and installs its dependencies
+func (c *Commander) Install(squad string) error {
+	bpDir := filepath.Join(c.SwatRoot, "blueprints")
+	squadDir := filepath.Join(bpDir, "squads", squad)
+
+	if fileExists(filepath.Join(squadDir, "MANIFEST.md")) {
+		return fmt.Errorf("squad %q is already installed", squad)
+	}
+
+	// Download squad from marketplace
+	if err := ghDownloadDir("squads/"+squad, squadDir); err != nil {
+		return fmt.Errorf("download squad %q: %w", squad, err)
+	}
+
+	// Verify MANIFEST.md exists
+	if !fileExists(filepath.Join(squadDir, "MANIFEST.md")) {
+		os.RemoveAll(squadDir)
+		return fmt.Errorf("squad %q not found in marketplace", squad)
+	}
+
+	// Resolve all dependencies (framework + squad + transitive skills)
+	allSkills := c.resolveDependencies(squad)
+	allMCPs := c.resolveMCPDependencies(squad)
+
+	// Install missing skills
+	for _, skill := range allSkills {
+		destSkill := filepath.Join(bpDir, "skills", skill)
+		if fileExists(destSkill) {
+			continue
+		}
+		if err := ghDownloadDir("skills/"+skill, destSkill); err != nil {
+			return fmt.Errorf("download skill %q: %w", skill, err)
+		}
+	}
+
+	// Install missing MCPs
+	for _, mcp := range allMCPs {
+		destMCP := filepath.Join(bpDir, "mcps", mcp+".json")
+		if fileExists(destMCP) {
+			continue
+		}
+		data, err := ghGetFile("mcps/" + mcp + ".json")
+		if err != nil {
+			return fmt.Errorf("download MCP %q: %w", mcp, err)
+		}
+		os.MkdirAll(filepath.Join(bpDir, "mcps"), 0755)
+		if err := os.WriteFile(destMCP, data, 0644); err != nil {
+			return fmt.Errorf("write MCP %q: %w", mcp, err)
+		}
+	}
+
+	return nil
+}
+
+// Uninstall removes a squad blueprint and cleans up orphaned dependencies
+func (c *Commander) Uninstall(squad string, purge bool) error {
+	bpDir := filepath.Join(c.SwatRoot, "blueprints")
+	squadBP := filepath.Join(bpDir, "squads", squad)
+
+	if !fileExists(filepath.Join(squadBP, "MANIFEST.md")) {
+		return fmt.Errorf("squad %q is not installed", squad)
+	}
+
+	// Check for active operations
+	ops, err := c.ListOperations()
+	if err == nil {
+		for _, op := range ops {
+			if op.Squad == squad && op.Status == "active" {
+				return fmt.Errorf("squad %q has active operation %s — cancel it first", squad, op.OperationID)
+			}
+		}
+	}
+
+	if err := os.RemoveAll(squadBP); err != nil {
+		return fmt.Errorf("remove squad blueprint: %w", err)
+	}
+
+	if purge {
+		runtimeDir := c.SquadDir(squad)
+		if fileExists(runtimeDir) {
+			os.RemoveAll(runtimeDir)
+		}
+	}
+
+	c.cleanOrphans()
+	return nil
+}
+
+// cleanOrphans removes skills and MCPs not referenced by any installed squad
+func (c *Commander) cleanOrphans() {
+	bpDir := filepath.Join(c.SwatRoot, "blueprints")
+
+	neededSkills := make(map[string]bool)
+	neededMCPs := make(map[string]bool)
+
+	squads, err := c.ListSquads()
+	if err != nil {
+		return
+	}
+
+	for _, sq := range squads {
+		name := sq["name"]
+		for _, skill := range c.resolveDependencies(name) {
+			neededSkills[skill] = true
+		}
+		for _, mcp := range c.resolveMCPDependencies(name) {
+			neededMCPs[mcp] = true
+		}
+	}
+
+	skillsDir := filepath.Join(bpDir, "skills")
+	if entries, err := os.ReadDir(skillsDir); err == nil {
+		for _, entry := range entries {
+			if entry.IsDir() && !neededSkills[entry.Name()] {
+				os.RemoveAll(filepath.Join(skillsDir, entry.Name()))
+			}
+		}
+	}
+
+	mcpsDir := filepath.Join(bpDir, "mcps")
+	if entries, err := os.ReadDir(mcpsDir); err == nil {
+		for _, entry := range entries {
+			name := entry.Name()
+			if filepath.Ext(name) == ".json" {
+				base := name[:len(name)-5]
+				if !neededMCPs[base] {
+					os.Remove(filepath.Join(mcpsDir, name))
+				}
+			}
+		}
+	}
+}
+
+// --- GitHub API helpers ---
+
+type ghEntry struct {
+	Name string `json:"name"`
+	Type string `json:"type"` // "file" or "dir"
+	Path string `json:"path"`
+}
+
+// ghListDir lists directory contents via GitHub Contents API
+func ghListDir(path string) ([]ghEntry, error) {
+	url := fmt.Sprintf("%s/contents/%s", marketplaceAPI, path)
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 404 {
+		return nil, fmt.Errorf("path %q not found in marketplace", path)
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("GitHub API returned %d", resp.StatusCode)
+	}
+
+	var entries []ghEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+// ghGetFile downloads a single file's raw content
+func ghGetFile(path string) ([]byte, error) {
+	url := fmt.Sprintf("https://raw.githubusercontent.com/LangSensei/swat-marketplace/main/%s", path)
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 404 {
+		return nil, fmt.Errorf("file %q not found", path)
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("HTTP %d fetching %s", resp.StatusCode, path)
+	}
+
+	return io.ReadAll(resp.Body)
+}
+
+// ghDownloadDir recursively downloads a directory from the marketplace
+func ghDownloadDir(remotePath, localDir string) error {
+	entries, err := ghListDir(remotePath)
+	if err != nil {
+		return err
+	}
+
+	os.MkdirAll(localDir, 0755)
+
+	for _, e := range entries {
+		localPath := filepath.Join(localDir, e.Name)
+		switch e.Type {
+		case "file":
+			data, err := ghGetFile(e.Path)
+			if err != nil {
+				return fmt.Errorf("download %s: %w", e.Path, err)
+			}
+			// Preserve executable bit for .sh files
+			perm := os.FileMode(0644)
+			if strings.HasSuffix(e.Name, ".sh") {
+				perm = 0755
+			}
+			if err := os.WriteFile(localPath, data, perm); err != nil {
+				return err
+			}
+		case "dir":
+			if err := ghDownloadDir(e.Path, localPath); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/install.sh
+++ b/install.sh
@@ -163,6 +163,57 @@ setup_runtime() {
 
 # --- Post-Install ---
 
+register_plugin() {
+    local oc_config="$HOME/.openclaw/openclaw.json"
+    local plugin_path="$SWAT_HOME/plugin"
+
+    if [[ ! -f "$oc_config" ]]; then
+        info "OpenClaw config not found at $oc_config"
+        info "After installing OpenClaw, add the SWAT plugin to your config:"
+        echo ""
+        echo "  plugins.load.paths: [\"$plugin_path\"]"
+        echo "  plugins.entries.swat-mcp-bridge.enabled: true"
+        echo ""
+        info "Then restart OpenClaw: openclaw gateway restart"
+        return
+    fi
+
+    # Check if already registered
+    if grep -q "$plugin_path" "$oc_config" 2>/dev/null; then
+        ok "Plugin already registered in OpenClaw config"
+        return
+    fi
+
+    # Use node to patch JSON config
+    if node -e "
+        const fs = require('fs');
+        const cfg = JSON.parse(fs.readFileSync('$oc_config', 'utf8'));
+
+        // Ensure plugins structure
+        cfg.plugins = cfg.plugins || {};
+        cfg.plugins.load = cfg.plugins.load || {};
+        cfg.plugins.load.paths = cfg.plugins.load.paths || [];
+        cfg.plugins.entries = cfg.plugins.entries || {};
+
+        // Add plugin path if not present
+        if (!cfg.plugins.load.paths.includes('$plugin_path')) {
+            cfg.plugins.load.paths.push('$plugin_path');
+        }
+
+        // Enable plugin
+        cfg.plugins.entries['swat-mcp-bridge'] = { enabled: true };
+
+        fs.writeFileSync('$oc_config', JSON.stringify(cfg, null, 2) + '\n');
+    " 2>/dev/null; then
+        ok "Plugin registered in OpenClaw config"
+        info "Restart OpenClaw to activate: openclaw gateway restart"
+    else
+        err "Failed to auto-register plugin. Manually add to $oc_config:"
+        echo "  plugins.load.paths: [\"$plugin_path\"]"
+        echo "  plugins.entries.swat-mcp-bridge.enabled: true"
+    fi
+}
+
 post_install() {
     # PATH check
     if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then
@@ -171,11 +222,7 @@ post_install() {
         echo ""
     fi
 
-    # OpenClaw plugin registration
-    info "Register the SWAT plugin in your OpenClaw config:"
-    echo "  \"plugins\": [\"$SWAT_HOME/plugin\"]"
-    echo ""
-    info "Then restart OpenClaw: openclaw gateway restart"
+    register_plugin
 }
 
 # --- Cleanup ---

--- a/install.sh
+++ b/install.sh
@@ -254,6 +254,12 @@ main() {
 
     # Record installed version
     echo "$TAG" > "$SWAT_HOME/.version"
+
+    echo ""
+    info "Next steps:"
+    echo "  1. Restart OpenClaw:  openclaw gateway restart"
+    echo "  2. Install a squad:   Tell your agent: \"browse SWAT marketplace and install a squad\""
+    echo "     Or use the tool directly: swat_browse → swat_install"
     echo ""
 }
 

--- a/mcp/handlers.go
+++ b/mcp/handlers.go
@@ -137,6 +137,12 @@ func (s *Server) handleToolCall(params callToolParams) toolResult {
 		return s.handleSquads(params.Arguments)
 	case "swat_schedule":
 		return s.handleSchedule(params.Arguments)
+	case "swat_install":
+		return s.handleInstall(params.Arguments)
+	case "swat_uninstall":
+		return s.handleUninstall(params.Arguments)
+	case "swat_browse":
+		return s.handleBrowse(params.Arguments)
 	default:
 		return toolResult{
 			Content: []contentBlock{{Type: "text", Text: fmt.Sprintf("unknown tool: %s", params.Name)}},
@@ -242,6 +248,73 @@ func (s *Server) handleSchedule(args map[string]interface{}) toolResult {
 	// TODO: create schedule entry
 	return toolResult{
 		Content: []contentBlock{{Type: "text", Text: "schedule not yet implemented"}},
+	}
+}
+
+func (s *Server) handleInstall(args map[string]interface{}) toolResult {
+	squad, _ := args["squad"].(string)
+	if squad == "" {
+		return toolResult{
+			Content: []contentBlock{{Type: "text", Text: "squad name is required"}},
+			IsError: true,
+		}
+	}
+
+	if err := s.Commander.Install(squad); err != nil {
+		return toolResult{
+			Content: []contentBlock{{Type: "text", Text: fmt.Sprintf("install failed: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	return toolResult{
+		Content: []contentBlock{{Type: "text", Text: fmt.Sprintf("squad %q installed successfully", squad)}},
+	}
+}
+
+func (s *Server) handleUninstall(args map[string]interface{}) toolResult {
+	squad, _ := args["squad"].(string)
+	if squad == "" {
+		return toolResult{
+			Content: []contentBlock{{Type: "text", Text: "squad name is required"}},
+			IsError: true,
+		}
+	}
+
+	purge, _ := args["purge"].(bool)
+
+	if err := s.Commander.Uninstall(squad, purge); err != nil {
+		return toolResult{
+			Content: []contentBlock{{Type: "text", Text: fmt.Sprintf("uninstall failed: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	msg := fmt.Sprintf("squad %q uninstalled", squad)
+	if purge {
+		msg += " (runtime data purged)"
+	}
+	return toolResult{
+		Content: []contentBlock{{Type: "text", Text: msg}},
+	}
+}
+
+func (s *Server) handleBrowse(args map[string]interface{}) toolResult {
+	results, err := s.Commander.Browse()
+	if err != nil {
+		return toolResult{
+			Content: []contentBlock{{Type: "text", Text: fmt.Sprintf("browse failed: %v", err)}},
+			IsError: true,
+		}
+	}
+	if len(results) == 0 {
+		return toolResult{
+			Content: []contentBlock{{Type: "text", Text: "no squads available in marketplace"}},
+		}
+	}
+	data, _ := json.MarshalIndent(results, "", "  ")
+	return toolResult{
+		Content: []contentBlock{{Type: "text", Text: string(data)}},
 	}
 }
 

--- a/mcp/mcp.go
+++ b/mcp/mcp.go
@@ -88,5 +88,36 @@ func (s *Server) Tools() []ToolDef {
 				"required": []string{"brief", "cron"},
 			},
 		},
+		{
+			Name:        "swat_install",
+			Description: "Install a squad from the SWAT marketplace (auto-resolves skill and MCP dependencies)",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"squad": map[string]interface{}{"type": "string", "description": "Squad name to install"},
+				},
+				"required": []string{"squad"},
+			},
+		},
+		{
+			Name:        "swat_uninstall",
+			Description: "Uninstall a squad and clean up orphaned dependencies",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"squad": map[string]interface{}{"type": "string", "description": "Squad name to uninstall"},
+					"purge": map[string]interface{}{"type": "boolean", "description": "Also delete runtime data and operation history (default: false)"},
+				},
+				"required": []string{"squad"},
+			},
+		},
+		{
+			Name:        "swat_browse",
+			Description: "List all squads available in the marketplace with install status",
+			InputSchema: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+			},
+		},
 	}
 }

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -4,6 +4,7 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { Type } from "@sinclair/typebox";
 import { spawn } from "child_process";
 import { resolve } from "path";
+import { homedir } from "os";
 
 let client: Client | null = null;
 let transport: StdioClientTransport | null = null;
@@ -15,7 +16,7 @@ function json(data: unknown) {
   };
 }
 
-const SWAT_BINARY = resolve(__dirname, "..", "swat");
+const SWAT_BINARY = resolve(homedir(), ".local", "bin", "swat");
 
 const TOOLS = [
   {

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -7,6 +7,7 @@
     "extensions": ["./index.ts"]
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0"
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@sinclair/typebox": "^0.34.0"
   }
 }

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,13 +1,6 @@
 # SWAT - Autonomous Squad Orchestration
 
-SWAT dispatches tasks to autonomous AI squads powered by GitHub Copilot CLI. Each squad is a specialist (coding, research, etc.) that works independently in the background.
-
-## When to Use
-
-- User wants a task done autonomously in the background
-- Tasks that benefit from a specialist agent (coding, research, writing)
-- Multiple tasks that can run in parallel
-- User says things like "do this for me", "handle this", "work on this in the background"
+SWAT dispatches tasks to autonomous AI squads powered by GitHub Copilot CLI. Each squad is a domain specialist that works independently in the background.
 
 ## Tools
 
@@ -15,49 +8,46 @@ SWAT dispatches tasks to autonomous AI squads powered by GitHub Copilot CLI. Eac
 |---|---|
 | `swat_dispatch` | Send a task to a squad |
 | `swat_status` | Check for completions and unnotified results |
-| `swat_squads` | List available squads |
+| `swat_squads` | List installed squads |
 | `swat_list` | List all operations with status |
 | `swat_cancel` | Cancel a running operation |
 | `swat_schedule` | Create a scheduled/recurring task |
+| `swat_browse` | List squads available in the marketplace |
+| `swat_install` | Install a squad from the marketplace |
+| `swat_uninstall` | Uninstall a squad and clean up dependencies |
 
-## How to Use
+## How to Dispatch
 
-### 1. Check available squads
-Call `swat_squads` to see what's installed. Each squad has a domain (e.g., coding, research).
+1. **Pick a squad** — Call `swat_squads` to see installed squads. If none fit, use `swat_browse` + `swat_install`.
+2. **Dispatch** — `swat_dispatch(brief, squad)`. Returns an operation ID immediately.
+3. **Tell the user** — Confirm the task is dispatched and which squad is on it.
+4. **Move on** — Do NOT wait, poll, or sleep. The squad works in the background.
 
-### 2. Dispatch a task
+## Checking Results
+
+- Call `swat_status` **only when the user asks** about a task, or when you have a natural reason to check (e.g., heartbeat).
+- **Never** use `sleep`, polling loops, or repeated `exec` calls to wait for completion. This blocks the main session and makes you unresponsive.
+- `swat_status` returns unnotified completions. Summarize the result to the user.
+- `swat_list` shows all operations if you need the full picture.
+
+## Critical Rules
+
+1. **Fire and forget** — After dispatch, immediately return control to the user. Do not monitor, poll, or block.
+2. **No sleep/exec polling** — Never run `sleep X && check` or similar patterns. SWAT tasks can take minutes; blocking the session makes you unreachable.
+3. **Squad selection matters** — Pick the squad whose domain matches the task. If no squad fits, say so.
+4. **Concurrent operations** — Multiple tasks can run in parallel across different squads.
+5. **Failed operations** — Include the failure reason when reporting to the user.
+
+## Marketplace
+
+- `swat_browse` — See what's available to install (fetches from GitHub, no clone needed).
+- `swat_install(squad)` — Downloads squad + resolves dependencies automatically.
+- `swat_uninstall(squad)` — Removes squad blueprint + cleans up orphaned dependencies.
+
+## First Run
+
+If SWAT tools are not available, guide the user to install:
 ```
-swat_dispatch:
-  brief: "Short task description" (required)
-  squad: "squad-name" (required — must match an installed squad)
-  details: "Additional context, requirements, links" (optional)
+curl -fsSL https://raw.githubusercontent.com/LangSensei/swat-v2/master/install.sh | bash
 ```
-
-### 3. Monitor progress
-- `swat_status` — Returns unnotified completions. Call after dispatch or periodically.
-- `swat_list` — Shows all operations (queued, active, completed, failed).
-
-### 4. Report results
-When `swat_status` returns a completed operation, summarize the result to the user.
-
-### 5. Cancel if needed
-```
-swat_cancel:
-  operation_id: "20260308-a1b2c3d4"
-```
-
-## Typical Flow
-
-1. User requests a task → check `swat_squads` if unsure which squad
-2. `swat_dispatch` with brief + squad → returns operation ID immediately
-3. Tell the user the task is dispatched and which squad is handling it
-4. Later, `swat_status` picks up the completion → summarize to user
-
-## Important Notes
-
-- **Dispatch is async** — the squad works in the background, don't wait for it
-- **Squad selection matters** — pick the squad whose domain matches the task
-- **If no squad fits** — tell the user; don't dispatch to a random squad
-- **Multiple operations** can run concurrently across different squads
-- **Results** are in OPERATION.md when status becomes `completed`
-- **Failed operations** include a failure reason in the status response
+Then restart OpenClaw. After that, install a squad: `swat_install("squad-name")`.

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SWAT v2 Uninstaller
+# Usage: curl -fsSL https://raw.githubusercontent.com/LangSensei/swat-v2/master/uninstall.sh | bash
+
+SWAT_HOME="$HOME/.swat"
+BIN_DIR="$HOME/.local/bin"
+
+info()  { echo -e "\033[0;36m[swat]\033[0m $*"; }
+ok()    { echo -e "\033[0;32m[swat]\033[0m $*"; }
+warn()  { echo -e "\033[0;33m[swat]\033[0m $*"; }
+err()   { echo -e "\033[0;31m[swat]\033[0m $*" >&2; }
+
+echo ""
+echo "  SWAT v2 Uninstaller"
+echo "  ==================="
+echo ""
+
+# --- Confirm -----------------------------------------------------------
+
+if [[ "${1:-}" != "--yes" ]]; then
+    warn "This will remove:"
+    echo "  - Binary:     $BIN_DIR/swat"
+    echo "  - Plugin:     $SWAT_HOME/plugin/"
+    echo "  - Blueprints: $SWAT_HOME/blueprints/"
+    echo "  - Version:    $SWAT_HOME/.version"
+    echo ""
+    warn "Runtime data ($SWAT_HOME/squads/) will be KEPT unless you pass --purge"
+    echo ""
+    read -r -p "Continue? [y/N] " confirm
+    if [[ "$confirm" != [yY] ]]; then
+        info "Aborted."
+        exit 0
+    fi
+fi
+
+PURGE=false
+for arg in "$@"; do
+    [[ "$arg" == "--purge" ]] && PURGE=true
+done
+
+# --- Remove binary -----------------------------------------------------
+
+if [[ -f "$BIN_DIR/swat" ]]; then
+    rm -f "$BIN_DIR/swat"
+    ok "Removed $BIN_DIR/swat"
+else
+    info "Binary not found at $BIN_DIR/swat (skipped)"
+fi
+
+# --- Remove plugin ------------------------------------------------------
+
+if [[ -d "$SWAT_HOME/plugin" ]]; then
+    rm -rf "$SWAT_HOME/plugin"
+    ok "Removed $SWAT_HOME/plugin/"
+fi
+
+# --- Remove blueprints --------------------------------------------------
+
+if [[ -d "$SWAT_HOME/blueprints" ]]; then
+    rm -rf "$SWAT_HOME/blueprints"
+    ok "Removed $SWAT_HOME/blueprints/"
+fi
+
+# --- Remove version file ------------------------------------------------
+
+rm -f "$SWAT_HOME/.version"
+
+# --- Purge runtime data -------------------------------------------------
+
+if $PURGE; then
+    if [[ -d "$SWAT_HOME/squads" ]]; then
+        rm -rf "$SWAT_HOME/squads"
+        ok "Purged $SWAT_HOME/squads/"
+    fi
+    # Remove entire .swat if empty
+    rmdir "$SWAT_HOME" 2>/dev/null && ok "Removed $SWAT_HOME/" || true
+else
+    if [[ -d "$SWAT_HOME/squads" ]]; then
+        info "Runtime data kept at $SWAT_HOME/squads/ (use --purge to remove)"
+    fi
+fi
+
+# --- Remove OpenClaw plugin config --------------------------------------
+
+OPENCLAW_CONFIG="$HOME/.openclaw/openclaw.json"
+if [[ -f "$OPENCLAW_CONFIG" ]] && command -v node &>/dev/null; then
+    node -e "
+        const fs = require('fs');
+        const cfg = JSON.parse(fs.readFileSync('$OPENCLAW_CONFIG', 'utf8'));
+        let changed = false;
+
+        // Remove from plugins.load.paths
+        if (cfg.plugins?.load?.paths) {
+            const before = cfg.plugins.load.paths.length;
+            cfg.plugins.load.paths = cfg.plugins.load.paths.filter(p => !p.includes('.swat/plugin'));
+            if (cfg.plugins.load.paths.length < before) changed = true;
+            if (cfg.plugins.load.paths.length === 0) delete cfg.plugins.load.paths;
+        }
+
+        // Remove plugin entry
+        if (cfg.plugins?.entries?.['swat-mcp-bridge']) {
+            delete cfg.plugins.entries['swat-mcp-bridge'];
+            changed = true;
+        }
+
+        if (changed) {
+            fs.writeFileSync('$OPENCLAW_CONFIG', JSON.stringify(cfg, null, 2) + '\n');
+            console.log('Removed SWAT plugin from OpenClaw config');
+        }
+    " 2>/dev/null && ok "Cleaned OpenClaw config" || true
+fi
+
+echo ""
+ok "SWAT v2 uninstalled."
+if ! $PURGE && [[ -d "$SWAT_HOME/squads" ]]; then
+    info "To fully remove all data: rm -rf $SWAT_HOME"
+fi
+echo ""


### PR DESCRIPTION
## Changes

### New: Marketplace tools (8 MCP tools total)
- `swat_install`: Clone marketplace → copy squad → resolve framework + squad deps → install missing skills/mcps
- `swat_uninstall`: Check no active ops → delete blueprint → optional purge → orphan cleanup

### Fix: Plugin binary path
- Use absolute path `~/.local/bin/swat` via `homedir()` instead of relative `__dirname/../swat`

### Files
- `commander/marketplace.go` — Install, Uninstall, cleanOrphans, fetchMarketplace
- `commander/fs.go` — add dirExists helper
- `mcp/mcp.go` + `mcp/handlers.go` — register 2 new tools + handlers
- `plugin/index.ts` — fix binary path resolution

### Testing
- Compiled and tested locally
- Full dispatch test passed (a-share-analyst squad, 贵州茅台 analysis completed)