### PR TITLE
fix: separate Commander state into dispatched.json

### DIFF
--- a/cmd/pidtest/main.go
+++ b/cmd/pidtest/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+func main() {
+	cmd := exec.Command("sleep", "30")
+	logFile, _ := os.Create("/tmp/pidtest2.log")
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	cmd.Start()
+	pid := cmd.Process.Pid
+	fmt.Printf("child PID: %d\n", pid)
+
+	go func() {
+		defer logFile.Close()
+		err := cmd.Wait()
+		fmt.Printf("[wait] returned: %v (%s)\n", err, time.Now().Format("15:04:05"))
+	}()
+
+	for i := 0; i < 8; i++ {
+		time.Sleep(5 * time.Second)
+
+		// Method 1: Signal(nil)
+		proc, _ := os.FindProcess(pid)
+		errNil := proc.Signal(nil)
+
+		// Method 2: Signal(syscall.Signal(0))
+		proc2, _ := os.FindProcess(pid)
+		errSig0 := proc2.Signal(syscall.Signal(0))
+
+		// Method 3: syscall.Kill(pid, 0)
+		errKill := syscall.Kill(pid, 0)
+
+		fmt.Printf("[%s] Signal(nil)=%-30v  Signal(0)=%-30v  Kill(0)=%v\n",
+			time.Now().Format("15:04:05"), errNil, errSig0, errKill)
+	}
+}

--- a/commander/collect.go
+++ b/commander/collect.go
@@ -2,7 +2,6 @@ package commander
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"time"
@@ -22,50 +21,51 @@ func (c *Commander) BackgroundLoop(interval time.Duration) {
 	}
 }
 
-// Scan checks all operations for state transitions
+// Scan checks all tracked operations for state transitions
 func (c *Commander) Scan() {
-	ops, err := c.ListOperations()
-	if err != nil {
-		log.Printf("[scan] error: %v", err)
-		return
+	c.Tracker.mu.Lock()
+	tracked := make(map[string]*TrackedOp, len(c.Tracker.Ops))
+	for id, t := range c.Tracker.Ops {
+		tracked[id] = t
 	}
+	c.Tracker.mu.Unlock()
+
 	c.RecentFailures = 0
-	for _, op := range ops {
-		if op.Status == "active" {
-			c.handleActive(op)
+	for opID, t := range tracked {
+		if t.FailedAt != nil || t.PID == 0 {
+			// Already resolved or not dispatched
+			continue
 		}
+		c.handleTracked(opID, t)
 	}
 }
 
-func (c *Commander) handleActive(op *Operation) {
+func (c *Commander) handleTracked(opID string, t *TrackedOp) {
 	// Process still running — nothing to do
-	if op.PID > 0 && processAlive(op.PID) {
-		// Track long-running operations for review
-		if op.DispatchedAt != nil && time.Since(*op.DispatchedAt) > 30*time.Minute {
+	if t.PID > 0 && processAlive(t.PID) {
+		if t.DispatchedAt != nil && time.Since(*t.DispatchedAt) > 30*time.Minute {
 			c.RecentFailures++
 		}
 		return
 	}
 
 	// Process exited — check if Captain completed the operation
-	now := time.Now().UTC()
-	opDir := c.OperationDir(op.Squad, op.OperationID)
+	opDir := c.OperationDir(t.Squad, opID)
 	reportExists := fileExists(filepath.Join(opDir, "report.html"))
-	opCompleted := fileContains(c.OperationMDPath(op.Squad, op.OperationID), "status: completed")
+	opCompleted := fileContains(c.OperationMDPath(t.Squad, opID), "status: completed")
 
 	if reportExists && opCompleted {
-		op.Status = "completed"
-		op.CompletedAt = &now
-		op.PID = 0
+		// Read OPERATION.md for summary
+		if op, err := c.LoadOperation(t.Squad, opID); err == nil {
+			t.PID = 0
+			c.Tracker.Save()
+			_ = op // summary is in OPERATION.md, available via MergeOperation
+		}
 	} else {
 		reason := "process_exited_without_completion"
-		op.Status = "failed"
-		op.FailedAt = &now
-		op.FailureReason = &reason
-		op.PID = 0
+		c.Tracker.SetFailed(opID, reason)
 		c.RecentFailures++
 	}
-	c.SaveOperation(op)
 }
 
 // ShouldReview determines if LLM review is needed
@@ -76,10 +76,11 @@ func (c *Commander) ShouldReview() bool {
 	if c.RecentFailures > 0 {
 		return true
 	}
-	ops, _ := c.ListOperations()
-	for _, op := range ops {
-		if op.Status == "active" && op.DispatchedAt != nil {
-			if time.Since(*op.DispatchedAt) > 30*time.Minute {
+	c.Tracker.mu.Lock()
+	defer c.Tracker.mu.Unlock()
+	for _, t := range c.Tracker.Ops {
+		if t.PID > 0 && t.DispatchedAt != nil {
+			if time.Since(*t.DispatchedAt) > 30*time.Minute {
 				return true
 			}
 		}
@@ -99,28 +100,24 @@ func processAlive(pid int) bool {
 }
 
 // GetUnnotified returns completed/failed operations not yet notified
-func (c *Commander) GetUnnotified() ([]*Operation, error) {
+func (c *Commander) GetUnnotified() ([]*FullOperation, error) {
 	ops, err := c.ListOperations()
 	if err != nil {
 		return nil, err
 	}
-	var result []*Operation
+	var result []*FullOperation
 	for _, op := range ops {
-		if (op.Status == "completed" || op.Status == "failed") && !op.Notified {
-			result = append(result, op)
+		full := c.MergeOperation(op)
+		if (full.Status == "completed" || full.Status == "failed") && !full.Notified {
+			result = append(result, full)
 		}
 	}
 	return result, nil
 }
 
-// MarkNotified sets notified=true for an operation
+// MarkNotified sets notified=true for an operation in the tracker
 func (c *Commander) MarkNotified(opID string) error {
-	op, err := c.findOperation(opID)
-	if err != nil {
-		return err
-	}
-	op.Notified = true
-	return c.SaveOperation(op)
+	return c.Tracker.SetNotified(opID)
 }
 
 // Status returns a summary of all operations
@@ -128,7 +125,8 @@ func (c *Commander) Status() map[string]interface{} {
 	ops, _ := c.ListOperations()
 	counts := map[string]int{"queued": 0, "active": 0, "completed": 0, "failed": 0}
 	for _, op := range ops {
-		counts[op.Status]++
+		full := c.MergeOperation(op)
+		counts[full.Status]++
 	}
 	unnotified, _ := c.GetUnnotified()
 

--- a/commander/collect.go
+++ b/commander/collect.go
@@ -122,16 +122,16 @@ func processAlive(pid int) bool {
 }
 
 // GetUnnotified returns completed/failed operations not yet notified
-func (c *Commander) GetUnnotified() ([]*FullOperation, error) {
+func (c *Commander) GetUnnotified() ([]*Operation, error) {
 	ops, err := c.ListOperations()
 	if err != nil {
 		return nil, err
 	}
-	var result []*FullOperation
+	var result []*Operation
 	for _, op := range ops {
-		full := c.MergeOperation(op)
-		if (full.Status == "completed" || full.Status == "failed") && !full.Notified {
-			result = append(result, full)
+		c.EnrichOperation(op)
+		if (op.Status == "completed" || op.Status == "failed") && !op.Notified {
+			result = append(result, op)
 		}
 	}
 	return result, nil
@@ -156,8 +156,8 @@ func (c *Commander) Status() map[string]interface{} {
 	ops, _ := c.ListOperations()
 	counts := map[string]int{"queued": 0, "active": 0, "completed": 0, "failed": 0}
 	for _, op := range ops {
-		full := c.MergeOperation(op)
-		counts[full.Status]++
+		c.EnrichOperation(op)
+		counts[op.Status]++
 	}
 	unnotified, _ := c.GetUnnotified()
 

--- a/commander/collect.go
+++ b/commander/collect.go
@@ -2,8 +2,8 @@ package commander
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
+	"syscall"
 	"time"
 )
 
@@ -42,7 +42,9 @@ func (c *Commander) Scan() {
 
 func (c *Commander) handleTracked(opID string, t *TrackedOp) {
 	// Process still running — nothing to do
-	if t.PID > 0 && processAlive(t.PID) {
+	alive := processAlive(t.PID)
+	debugLog(fmt.Sprintf("[scan] op=%s pid=%d alive=%v", opID, t.PID, alive))
+	if t.PID > 0 && alive {
 		if t.DispatchedAt != nil && time.Since(*t.DispatchedAt) > 30*time.Minute {
 			c.RecentFailures++
 		}
@@ -114,11 +116,10 @@ func processAlive(pid int) bool {
 	if pid == 0 {
 		return false
 	}
-	process, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	return process.Signal(nil) == nil
+	// Use raw syscall instead of os.FindProcess().Signal(nil),
+	// because Go marks the process as "finished" after cmd.Wait() returns,
+	// even if the process is still running (PID still valid in OS).
+	return syscall.Kill(pid, 0) == nil
 }
 
 // GetUnnotified returns completed/failed operations not yet notified

--- a/commander/collect.go
+++ b/commander/collect.go
@@ -55,17 +55,39 @@ func (c *Commander) handleTracked(opID string, t *TrackedOp) {
 	opCompleted := fileContains(c.OperationMDPath(t.Squad, opID), "status: completed")
 
 	if reportExists && opCompleted {
-		// Read OPERATION.md for summary
-		if op, err := c.LoadOperation(t.Squad, opID); err == nil {
-			t.PID = 0
-			c.Tracker.Save()
-			_ = op // summary is in OPERATION.md, available via MergeOperation
-		}
+		// Finalize: write tracker info back to OPERATION.md, then clean tracker
+		c.finalizeOperation(opID, t, "completed", nil)
 	} else {
 		reason := "process_exited_without_completion"
-		c.Tracker.SetFailed(opID, reason)
+		c.finalizeOperation(opID, t, "failed", &reason)
 		c.RecentFailures++
 	}
+}
+
+// finalizeOperation writes tracker state back into OPERATION.md and removes from tracker.
+// Safe because the process has exited — Captain is no longer writing.
+func (c *Commander) finalizeOperation(opID string, t *TrackedOp, status string, failReason *string) {
+	op, err := c.LoadOperation(t.Squad, opID)
+	if err != nil {
+		return
+	}
+
+	// Write Commander-tracked fields into OPERATION.md
+	now := time.Now().UTC()
+	op.DispatchedAt = t.DispatchedAt
+	op.FailedAt = t.FailedAt
+	op.FailureReason = t.FailureReason
+
+	if status == "completed" {
+		op.CompletedAt = &now
+	} else if status == "failed" {
+		op.Status = "failed"
+		op.FailedAt = &now
+		op.FailureReason = failReason
+	}
+
+	c.SaveOperation(op)
+	c.Tracker.Remove(opID)
 }
 
 // ShouldReview determines if LLM review is needed
@@ -115,9 +137,18 @@ func (c *Commander) GetUnnotified() ([]*FullOperation, error) {
 	return result, nil
 }
 
-// MarkNotified sets notified=true for an operation in the tracker
+// MarkNotified sets notified=true. Writes to tracker if in-flight, otherwise to OPERATION.md.
 func (c *Commander) MarkNotified(opID string) error {
-	return c.Tracker.SetNotified(opID)
+	if tracked := c.Tracker.Get(opID); tracked != nil {
+		return c.Tracker.SetNotified(opID)
+	}
+	// Finalized — update OPERATION.md directly
+	op, err := c.findOperation(opID)
+	if err != nil {
+		return err
+	}
+	op.Notified = true
+	return c.SaveOperation(op)
 }
 
 // Status returns a summary of all operations

--- a/commander/collect.go
+++ b/commander/collect.go
@@ -2,6 +2,7 @@ package commander
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"syscall"
 	"time"
@@ -116,10 +117,13 @@ func processAlive(pid int) bool {
 	if pid == 0 {
 		return false
 	}
-	// Use raw syscall instead of os.FindProcess().Signal(nil),
-	// because Go marks the process as "finished" after cmd.Wait() returns,
-	// even if the process is still running (PID still valid in OS).
-	return syscall.Kill(pid, 0) == nil
+	// Use Signal(0) instead of Signal(nil) — Go 1.24's pidfd path
+	// rejects nil as "unsupported signal type", but Signal(0) works correctly.
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return p.Signal(syscall.Signal(0)) == nil
 }
 
 // GetUnnotified returns completed/failed operations not yet notified

--- a/commander/commander.go
+++ b/commander/commander.go
@@ -20,24 +20,6 @@ type Operation struct {
 	Details       string     `json:"details,omitempty"`
 	Status        string     `json:"status"`
 	Source        string     `json:"source"`
-	CreatedAt     time.Time  `json:"created_at"`
-	DispatchedAt  *time.Time `json:"dispatched_at,omitempty"`
-	CompletedAt   *time.Time `json:"completed_at,omitempty"`
-	FailedAt      *time.Time `json:"failed_at,omitempty"`
-	FailureReason *string    `json:"failure_reason,omitempty"`
-	Summary       string     `json:"summary,omitempty"`
-	Notified      bool       `json:"notified"`
-}
-
-// FullOperation merges Operation (from OPERATION.md) with TrackedOp (from dispatched.json)
-// for external-facing responses. When tracker entry exists, operation is in-flight.
-// When tracker entry is gone, all data is in OPERATION.md.
-type FullOperation struct {
-	OperationID   string     `json:"operation_id"`
-	Squad         string     `json:"squad"`
-	Brief         string     `json:"brief"`
-	Status        string     `json:"status"`
-	Source        string     `json:"source"`
 	Notified      bool       `json:"notified"`
 	RetryCount    int        `json:"retry_count"`
 	CreatedAt     time.Time  `json:"created_at"`
@@ -169,6 +151,7 @@ func buildOperationFile(op *Operation) string {
 	sb.WriteString(fmt.Sprintf("status: %s\n", op.Status))
 	sb.WriteString(fmt.Sprintf("source: %s\n", op.Source))
 	sb.WriteString(fmt.Sprintf("notified: %v\n", op.Notified))
+	sb.WriteString(fmt.Sprintf("retry_count: %d\n", op.RetryCount))
 	sb.WriteString(fmt.Sprintf("created_at: %s\n", op.CreatedAt.Format(time.RFC3339)))
 	writeOptionalTime(&sb, "dispatched_at", op.DispatchedAt)
 	writeOptionalTime(&sb, "completed_at", op.CompletedAt)
@@ -243,6 +226,8 @@ func parseOperationMD(content string) (*Operation, error) {
 			op.Source = val
 		case "notified":
 			op.Notified = val == "true"
+		case "retry_count":
+			fmt.Sscanf(val, "%d", &op.RetryCount)
 		case "created_at":
 			if t, err := time.Parse(time.RFC3339, val); err == nil {
 				op.CreatedAt = t
@@ -273,38 +258,24 @@ func parseOperationMD(content string) (*Operation, error) {
 	return op, nil
 }
 
-// MergeOperation combines OPERATION.md + tracker into a FullOperation for external APIs.
-// If tracker entry exists (in-flight), use tracker for PID-related fields.
-// If tracker entry is gone (finalized), all data is in OPERATION.md.
-func (c *Commander) MergeOperation(op *Operation) *FullOperation {
-	full := &FullOperation{
-		OperationID:   op.OperationID,
-		Squad:         op.Squad,
-		Brief:         op.Brief,
-		Status:        op.Status,
-		Source:        op.Source,
-		Notified:      op.Notified,
-		CreatedAt:     op.CreatedAt,
-		DispatchedAt:  op.DispatchedAt,
-		CompletedAt:   op.CompletedAt,
-		FailedAt:      op.FailedAt,
-		FailureReason: op.FailureReason,
-		Summary:       op.Summary,
+// EnrichOperation overlays live tracker data onto an Operation for external APIs.
+// If tracker entry exists (in-flight), override status and timing fields.
+// If tracker entry is gone (finalized), Operation already has all data.
+func (c *Commander) EnrichOperation(op *Operation) {
+	tracked := c.Tracker.Get(op.OperationID)
+	if tracked == nil {
+		return
 	}
-	// Override with live tracker data if operation is still in-flight
-	if tracked := c.Tracker.Get(op.OperationID); tracked != nil {
-		full.RetryCount = tracked.RetryCount
-		full.DispatchedAt = tracked.DispatchedAt
-		if tracked.PID > 0 && processAlive(tracked.PID) {
-			full.Status = "active"
-		}
-		if tracked.FailedAt != nil {
-			full.Status = "failed"
-			full.FailedAt = tracked.FailedAt
-			full.FailureReason = tracked.FailureReason
-		}
+	op.RetryCount = tracked.RetryCount
+	op.DispatchedAt = tracked.DispatchedAt
+	if tracked.PID > 0 && processAlive(tracked.PID) {
+		op.Status = "active"
 	}
-	return full
+	if tracked.FailedAt != nil {
+		op.Status = "failed"
+		op.FailedAt = tracked.FailedAt
+		op.FailureReason = tracked.FailureReason
+	}
 }
 
 // findOperation locates an operation by ID across all squads

--- a/commander/commander.go
+++ b/commander/commander.go
@@ -11,22 +11,27 @@ import (
 )
 
 // Operation represents a task parsed from OPERATION.md frontmatter.
-// This is the Captain-owned file — Commander only writes it at creation time.
+// Commander writes it at creation and at finalization (after process exits).
+// Captain owns it during execution.
 type Operation struct {
-	OperationID string    `json:"operation_id"`
-	Squad       string    `json:"squad"`
-	Brief       string    `json:"brief"`
-	Details     string    `json:"details,omitempty"`
-	Status      string    `json:"status"`
-	Source      string    `json:"source"`
-	CreatedAt   time.Time `json:"created_at"`
-	CompletedAt *time.Time `json:"completed_at,omitempty"`
-	Summary     string    `json:"summary,omitempty"`
-	References  string    `json:"references,omitempty"`
+	OperationID   string     `json:"operation_id"`
+	Squad         string     `json:"squad"`
+	Brief         string     `json:"brief"`
+	Details       string     `json:"details,omitempty"`
+	Status        string     `json:"status"`
+	Source        string     `json:"source"`
+	CreatedAt     time.Time  `json:"created_at"`
+	DispatchedAt  *time.Time `json:"dispatched_at,omitempty"`
+	CompletedAt   *time.Time `json:"completed_at,omitempty"`
+	FailedAt      *time.Time `json:"failed_at,omitempty"`
+	FailureReason *string    `json:"failure_reason,omitempty"`
+	Summary       string     `json:"summary,omitempty"`
+	Notified      bool       `json:"notified"`
 }
 
 // FullOperation merges Operation (from OPERATION.md) with TrackedOp (from dispatched.json)
-// for external-facing responses (MCP status, list, etc.)
+// for external-facing responses. When tracker entry exists, operation is in-flight.
+// When tracker entry is gone, all data is in OPERATION.md.
 type FullOperation struct {
 	OperationID   string     `json:"operation_id"`
 	Squad         string     `json:"squad"`
@@ -163,8 +168,12 @@ func buildOperationFile(op *Operation) string {
 	sb.WriteString(fmt.Sprintf("brief: %s\n", op.Brief))
 	sb.WriteString(fmt.Sprintf("status: %s\n", op.Status))
 	sb.WriteString(fmt.Sprintf("source: %s\n", op.Source))
+	sb.WriteString(fmt.Sprintf("notified: %v\n", op.Notified))
 	sb.WriteString(fmt.Sprintf("created_at: %s\n", op.CreatedAt.Format(time.RFC3339)))
+	writeOptionalTime(&sb, "dispatched_at", op.DispatchedAt)
 	writeOptionalTime(&sb, "completed_at", op.CompletedAt)
+	writeOptionalTime(&sb, "failed_at", op.FailedAt)
+	writeOptionalStr(&sb, "failure_reason", op.FailureReason)
 	writeOptionalStr(&sb, "summary", nilIfEmpty(op.Summary))
 	sb.WriteString("references: []\n")
 	sb.WriteString("---\n\n")
@@ -232,13 +241,27 @@ func parseOperationMD(content string) (*Operation, error) {
 			op.Status = val
 		case "source":
 			op.Source = val
+		case "notified":
+			op.Notified = val == "true"
 		case "created_at":
 			if t, err := time.Parse(time.RFC3339, val); err == nil {
 				op.CreatedAt = t
 			}
+		case "dispatched_at":
+			if t, err := time.Parse(time.RFC3339, val); err == nil {
+				op.DispatchedAt = &t
+			}
 		case "completed_at":
 			if t, err := time.Parse(time.RFC3339, val); err == nil {
 				op.CompletedAt = &t
+			}
+		case "failed_at":
+			if t, err := time.Parse(time.RFC3339, val); err == nil {
+				op.FailedAt = &t
+			}
+		case "failure_reason":
+			if val != "" {
+				op.FailureReason = &val
 			}
 		case "summary":
 			op.Summary = val
@@ -250,31 +273,35 @@ func parseOperationMD(content string) (*Operation, error) {
 	return op, nil
 }
 
-// MergeOperation combines OPERATION.md + tracker into a FullOperation for external APIs
+// MergeOperation combines OPERATION.md + tracker into a FullOperation for external APIs.
+// If tracker entry exists (in-flight), use tracker for PID-related fields.
+// If tracker entry is gone (finalized), all data is in OPERATION.md.
 func (c *Commander) MergeOperation(op *Operation) *FullOperation {
 	full := &FullOperation{
-		OperationID: op.OperationID,
-		Squad:       op.Squad,
-		Brief:       op.Brief,
-		Status:      op.Status,
-		Source:      op.Source,
-		CreatedAt:   op.CreatedAt,
-		CompletedAt: op.CompletedAt,
-		Summary:     op.Summary,
+		OperationID:   op.OperationID,
+		Squad:         op.Squad,
+		Brief:         op.Brief,
+		Status:        op.Status,
+		Source:        op.Source,
+		Notified:      op.Notified,
+		CreatedAt:     op.CreatedAt,
+		DispatchedAt:  op.DispatchedAt,
+		CompletedAt:   op.CompletedAt,
+		FailedAt:      op.FailedAt,
+		FailureReason: op.FailureReason,
+		Summary:       op.Summary,
 	}
+	// Override with live tracker data if operation is still in-flight
 	if tracked := c.Tracker.Get(op.OperationID); tracked != nil {
-		full.Notified = tracked.Notified
 		full.RetryCount = tracked.RetryCount
 		full.DispatchedAt = tracked.DispatchedAt
-		full.FailedAt = tracked.FailedAt
-		full.FailureReason = tracked.FailureReason
-		// If tracker says failed but Captain wrote completed, trust Captain
-		if op.Status == "completed" && tracked.FailedAt != nil {
-			full.Status = "completed"
+		if tracked.PID > 0 && processAlive(tracked.PID) {
+			full.Status = "active"
 		}
-		// If process exited and Captain didn't complete, use tracker's failed status
-		if op.Status != "completed" && tracked.FailedAt != nil {
+		if tracked.FailedAt != nil {
 			full.Status = "failed"
+			full.FailedAt = tracked.FailedAt
+			full.FailureReason = tracked.FailureReason
 		}
 	}
 	return full

--- a/commander/commander.go
+++ b/commander/commander.go
@@ -10,17 +10,31 @@ import (
 	"time"
 )
 
-// Operation represents a task parsed from OPERATION.md frontmatter
+// Operation represents a task parsed from OPERATION.md frontmatter.
+// This is the Captain-owned file — Commander only writes it at creation time.
 type Operation struct {
+	OperationID string    `json:"operation_id"`
+	Squad       string    `json:"squad"`
+	Brief       string    `json:"brief"`
+	Details     string    `json:"details,omitempty"`
+	Status      string    `json:"status"`
+	Source      string    `json:"source"`
+	CreatedAt   time.Time `json:"created_at"`
+	CompletedAt *time.Time `json:"completed_at,omitempty"`
+	Summary     string    `json:"summary,omitempty"`
+	References  string    `json:"references,omitempty"`
+}
+
+// FullOperation merges Operation (from OPERATION.md) with TrackedOp (from dispatched.json)
+// for external-facing responses (MCP status, list, etc.)
+type FullOperation struct {
 	OperationID   string     `json:"operation_id"`
 	Squad         string     `json:"squad"`
 	Brief         string     `json:"brief"`
-	Details       string     `json:"details,omitempty"`
 	Status        string     `json:"status"`
-	PID           int        `json:"pid,omitempty"`
+	Source        string     `json:"source"`
 	Notified      bool       `json:"notified"`
 	RetryCount    int        `json:"retry_count"`
-	Source        string     `json:"source"`
 	CreatedAt     time.Time  `json:"created_at"`
 	DispatchedAt  *time.Time `json:"dispatched_at,omitempty"`
 	CompletedAt   *time.Time `json:"completed_at,omitempty"`
@@ -44,9 +58,9 @@ type Schedule struct {
 // Commander is the core orchestrator
 type Commander struct {
 	SwatRoot       string
+	Tracker        *Tracker
 	Iteration      int
 	RecentFailures int
-	RetryCount     map[string]int
 }
 
 // New creates a new Commander instance
@@ -55,9 +69,11 @@ func New(swatRoot string) *Commander {
 		home, _ := os.UserHomeDir()
 		swatRoot = filepath.Join(home, swatRoot[2:])
 	}
+	tracker := NewTracker(swatRoot)
+	tracker.Load() // best-effort; empty map on first run
 	return &Commander{
-		SwatRoot:   swatRoot,
-		RetryCount: make(map[string]int),
+		SwatRoot: swatRoot,
+		Tracker:  tracker,
 	}
 }
 
@@ -147,14 +163,8 @@ func buildOperationFile(op *Operation) string {
 	sb.WriteString(fmt.Sprintf("brief: %s\n", op.Brief))
 	sb.WriteString(fmt.Sprintf("status: %s\n", op.Status))
 	sb.WriteString(fmt.Sprintf("source: %s\n", op.Source))
-	sb.WriteString(fmt.Sprintf("pid: %d\n", op.PID))
-	sb.WriteString(fmt.Sprintf("notified: %v\n", op.Notified))
-	sb.WriteString(fmt.Sprintf("retry_count: %d\n", op.RetryCount))
 	sb.WriteString(fmt.Sprintf("created_at: %s\n", op.CreatedAt.Format(time.RFC3339)))
-	writeOptionalTime(&sb, "dispatched_at", op.DispatchedAt)
 	writeOptionalTime(&sb, "completed_at", op.CompletedAt)
-	writeOptionalTime(&sb, "failed_at", op.FailedAt)
-	writeOptionalStr(&sb, "failure_reason", op.FailureReason)
 	writeOptionalStr(&sb, "summary", nilIfEmpty(op.Summary))
 	sb.WriteString("references: []\n")
 	sb.WriteString("---\n\n")
@@ -222,31 +232,13 @@ func parseOperationMD(content string) (*Operation, error) {
 			op.Status = val
 		case "source":
 			op.Source = val
-		case "pid":
-			fmt.Sscanf(val, "%d", &op.PID)
-		case "notified":
-			op.Notified = val == "true"
-		case "retry_count":
-			fmt.Sscanf(val, "%d", &op.RetryCount)
 		case "created_at":
 			if t, err := time.Parse(time.RFC3339, val); err == nil {
 				op.CreatedAt = t
 			}
-		case "dispatched_at":
-			if t, err := time.Parse(time.RFC3339, val); err == nil {
-				op.DispatchedAt = &t
-			}
 		case "completed_at":
 			if t, err := time.Parse(time.RFC3339, val); err == nil {
 				op.CompletedAt = &t
-			}
-		case "failed_at":
-			if t, err := time.Parse(time.RFC3339, val); err == nil {
-				op.FailedAt = &t
-			}
-		case "failure_reason":
-			if val != "" {
-				op.FailureReason = &val
 			}
 		case "summary":
 			op.Summary = val
@@ -256,6 +248,36 @@ func parseOperationMD(content string) (*Operation, error) {
 		return nil, fmt.Errorf("missing operation_id in frontmatter")
 	}
 	return op, nil
+}
+
+// MergeOperation combines OPERATION.md + tracker into a FullOperation for external APIs
+func (c *Commander) MergeOperation(op *Operation) *FullOperation {
+	full := &FullOperation{
+		OperationID: op.OperationID,
+		Squad:       op.Squad,
+		Brief:       op.Brief,
+		Status:      op.Status,
+		Source:      op.Source,
+		CreatedAt:   op.CreatedAt,
+		CompletedAt: op.CompletedAt,
+		Summary:     op.Summary,
+	}
+	if tracked := c.Tracker.Get(op.OperationID); tracked != nil {
+		full.Notified = tracked.Notified
+		full.RetryCount = tracked.RetryCount
+		full.DispatchedAt = tracked.DispatchedAt
+		full.FailedAt = tracked.FailedAt
+		full.FailureReason = tracked.FailureReason
+		// If tracker says failed but Captain wrote completed, trust Captain
+		if op.Status == "completed" && tracked.FailedAt != nil {
+			full.Status = "completed"
+		}
+		// If process exited and Captain didn't complete, use tracker's failed status
+		if op.Status != "completed" && tracked.FailedAt != nil {
+			full.Status = "failed"
+		}
+	}
+	return full
 }
 
 // findOperation locates an operation by ID across all squads

--- a/commander/dispatch.go
+++ b/commander/dispatch.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Dispatch creates a new operation and launches it immediately
-func (c *Commander) Dispatch(brief, details, squad string) (*Operation, error) {
+func (c *Commander) Dispatch(brief, details, squad string) (*FullOperation, error) {
 	now := time.Now().UTC()
 	op := &Operation{
 		OperationID: GenerateOpID(),
@@ -25,40 +25,28 @@ func (c *Commander) Dispatch(brief, details, squad string) (*Operation, error) {
 		return nil, err
 	}
 
+	full := c.MergeOperation(op)
+
 	// Launch immediately
 	go func() {
 		if err := c.launchOne(op); err != nil {
-			now := time.Now().UTC()
 			reason := fmt.Sprintf("launch_failed: %v", err)
-			op.Status = "failed"
-			op.FailedAt = &now
-			op.FailureReason = &reason
-			c.SaveOperation(op)
+			c.Tracker.SetFailed(op.OperationID, reason)
 		}
 	}()
 
-	return op, nil
+	return full, nil
 }
 
 // Cancel marks an operation as failed and kills the process if active
 func (c *Commander) Cancel(opID string) error {
-	op, err := c.findOperation(opID)
-	if err != nil {
-		return err
-	}
-	now := time.Now().UTC()
-	reason := "cancelled_by_user"
-
-	if op.Status == "active" && op.PID > 0 {
-		if p, err := os.FindProcess(op.PID); err == nil {
+	// Kill process if tracked
+	if tracked := c.Tracker.Get(opID); tracked != nil && tracked.PID > 0 {
+		if p, err := os.FindProcess(tracked.PID); err == nil {
 			p.Signal(os.Kill)
 		}
 	}
-
-	op.Status = "failed"
-	op.FailedAt = &now
-	op.FailureReason = &reason
-	return c.SaveOperation(op)
+	return c.Tracker.SetFailed(opID, "cancelled_by_user")
 }
 
 // launchOne prepares the operation directory and starts a Copilot CLI process
@@ -88,11 +76,12 @@ func (c *Commander) launchOne(op *Operation) error {
 	}
 
 	now := time.Now().UTC()
-	op.Status = "active"
-	op.PID = cmd.Process.Pid
-	op.DispatchedAt = &now
-
-	if err := c.SaveOperation(op); err != nil {
+	tracked := &TrackedOp{
+		Squad:        op.Squad,
+		PID:          cmd.Process.Pid,
+		DispatchedAt: &now,
+	}
+	if err := c.Tracker.Track(op.OperationID, tracked); err != nil {
 		cmd.Process.Kill()
 		logFile.Close()
 		return err

--- a/commander/dispatch.go
+++ b/commander/dispatch.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Dispatch creates a new operation and launches it immediately
-func (c *Commander) Dispatch(brief, details, squad string) (*FullOperation, error) {
+func (c *Commander) Dispatch(brief, details, squad string) (*Operation, error) {
 	now := time.Now().UTC()
 	op := &Operation{
 		OperationID: GenerateOpID(),
@@ -25,8 +25,6 @@ func (c *Commander) Dispatch(brief, details, squad string) (*FullOperation, erro
 		return nil, err
 	}
 
-	full := c.MergeOperation(op)
-
 	// Launch immediately
 	go func() {
 		if err := c.launchOne(op); err != nil {
@@ -35,7 +33,7 @@ func (c *Commander) Dispatch(brief, details, squad string) (*FullOperation, erro
 		}
 	}()
 
-	return full, nil
+	return op, nil
 }
 
 // Cancel marks an operation as failed and kills the process if active

--- a/commander/fs.go
+++ b/commander/fs.go
@@ -1,9 +1,11 @@
 package commander
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 	"strings"
 )
 
@@ -50,4 +52,14 @@ func copyDir(src, dst string) error {
 // execCommand creates an exec.Cmd
 func execCommand(name string, args ...string) *exec.Cmd {
 	return exec.Command(name, args...)
+}
+
+func debugLog(msg string) {
+	home, _ := os.UserHomeDir()
+	f, err := os.OpenFile(filepath.Join(home, ".swat", "debug.log"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	fmt.Fprintf(f, "%s %s\n", time.Now().UTC().Format("15:04:05"), msg)
 }

--- a/commander/tracker.go
+++ b/commander/tracker.go
@@ -1,0 +1,122 @@
+package commander
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// TrackedOp holds Commander-internal state for a dispatched operation
+type TrackedOp struct {
+	Squad         string     `json:"squad"`
+	PID           int        `json:"pid"`
+	Notified      bool       `json:"notified"`
+	RetryCount    int        `json:"retry_count"`
+	DispatchedAt  *time.Time `json:"dispatched_at,omitempty"`
+	FailedAt      *time.Time `json:"failed_at,omitempty"`
+	FailureReason *string    `json:"failure_reason,omitempty"`
+}
+
+// Tracker manages dispatched.json — Commander's internal state file
+type Tracker struct {
+	mu   sync.Mutex
+	path string
+	Ops  map[string]*TrackedOp `json:"ops"`
+}
+
+// NewTracker creates a tracker backed by dispatched.json in swatRoot
+func NewTracker(swatRoot string) *Tracker {
+	return &Tracker{
+		path: filepath.Join(swatRoot, "dispatched.json"),
+		Ops:  make(map[string]*TrackedOp),
+	}
+}
+
+// Load reads dispatched.json from disk
+func (t *Tracker) Load() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	data, err := os.ReadFile(t.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			t.Ops = make(map[string]*TrackedOp)
+			return nil
+		}
+		return err
+	}
+	wrapper := struct {
+		Ops map[string]*TrackedOp `json:"ops"`
+	}{}
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		return err
+	}
+	t.Ops = wrapper.Ops
+	if t.Ops == nil {
+		t.Ops = make(map[string]*TrackedOp)
+	}
+	return nil
+}
+
+// Save writes dispatched.json to disk
+func (t *Tracker) Save() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	wrapper := struct {
+		Ops map[string]*TrackedOp `json:"ops"`
+	}{Ops: t.Ops}
+	data, err := json.MarshalIndent(wrapper, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(t.path, data, 0644)
+}
+
+// Track adds or updates a tracked operation
+func (t *Tracker) Track(opID string, tracked *TrackedOp) error {
+	t.mu.Lock()
+	t.Ops[opID] = tracked
+	t.mu.Unlock()
+	return t.Save()
+}
+
+// Get returns the tracked state for an operation
+func (t *Tracker) Get(opID string) *TrackedOp {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.Ops[opID]
+}
+
+// Remove deletes a tracked operation
+func (t *Tracker) Remove(opID string) error {
+	t.mu.Lock()
+	delete(t.Ops, opID)
+	t.mu.Unlock()
+	return t.Save()
+}
+
+// SetNotified marks a tracked operation as notified
+func (t *Tracker) SetNotified(opID string) error {
+	t.mu.Lock()
+	if op, ok := t.Ops[opID]; ok {
+		op.Notified = true
+	}
+	t.mu.Unlock()
+	return t.Save()
+}
+
+// SetFailed marks a tracked operation as failed
+func (t *Tracker) SetFailed(opID string, reason string) error {
+	t.mu.Lock()
+	if op, ok := t.Ops[opID]; ok {
+		now := time.Now().UTC()
+		op.FailedAt = &now
+		op.FailureReason = &reason
+		op.PID = 0
+	}
+	t.mu.Unlock()
+	return t.Save()
+}

--- a/mcp/handlers.go
+++ b/mcp/handlers.go
@@ -187,23 +187,24 @@ func (s *Server) handleList(args map[string]interface{}) toolResult {
 		}
 	}
 
-	var fullOps []*commander.FullOperation
+	var enriched []*commander.Operation
 	for _, op := range ops {
-		fullOps = append(fullOps, s.Commander.MergeOperation(op))
+		s.Commander.EnrichOperation(op)
+		enriched = append(enriched, op)
 	}
 
 	statusFilter, _ := args["status"].(string)
 	if statusFilter != "" {
-		var filtered []*commander.FullOperation
-		for _, op := range fullOps {
+		var filtered []*commander.Operation
+		for _, op := range enriched {
 			if op.Status == statusFilter {
 				filtered = append(filtered, op)
 			}
 		}
-		fullOps = filtered
+		enriched = filtered
 	}
 
-	data, _ := json.MarshalIndent(fullOps, "", "  ")
+	data, _ := json.MarshalIndent(enriched, "", "  ")
 	return toolResult{
 		Content: []contentBlock{{Type: "text", Text: string(data)}},
 	}

--- a/mcp/handlers.go
+++ b/mcp/handlers.go
@@ -187,18 +187,23 @@ func (s *Server) handleList(args map[string]interface{}) toolResult {
 		}
 	}
 
+	var fullOps []*commander.FullOperation
+	for _, op := range ops {
+		fullOps = append(fullOps, s.Commander.MergeOperation(op))
+	}
+
 	statusFilter, _ := args["status"].(string)
 	if statusFilter != "" {
-		var filtered []*commander.Operation
-		for _, op := range ops {
+		var filtered []*commander.FullOperation
+		for _, op := range fullOps {
 			if op.Status == statusFilter {
 				filtered = append(filtered, op)
 			}
 		}
-		ops = filtered
+		fullOps = filtered
 	}
 
-	data, _ := json.MarshalIndent(ops, "", "  ")
+	data, _ := json.MarshalIndent(fullOps, "", "  ")
 	return toolResult{
 		Content: []contentBlock{{Type: "text", Text: string(data)}},
 	}


### PR DESCRIPTION
## Problem
Commander and Captain both wrote OPERATION.md, causing a race condition. Captain editing frontmatter could corrupt the PID field, making Scan falsely mark active operations as failed.

## Solution
- New `dispatched.json` (Commander-owned): stores PID, notified, retry_count, dispatched_at, failed_at, failure_reason
- OPERATION.md (Captain-owned after creation): stores operation_id, squad, brief, status, source, created_at, completed_at, summary, references
- Commander writes OPERATION.md only once at creation; Captain has full ownership after dispatch
- New `FullOperation` type merges both sources for external-facing APIs (status, list)
- Scan reads PID from tracker, checks OPERATION.md only for Captain's status field

## Files changed
- **New** `commander/tracker.go` — dispatched.json read/write with mutex
- **Modified** `commander/commander.go` — slimmed Operation struct, added FullOperation + MergeOperation
- **Modified** `commander/collect.go` — Scan uses tracker instead of OPERATION.md for PID
- **Modified** `commander/dispatch.go` — PID writes to tracker, Dispatch returns FullOperation
- **Modified** `mcp/handlers.go` — handleList uses FullOperation