### PR TITLE
fix: processAlive broken on Go 1.24

### DIFF
--- a/commander/collect.go
+++ b/commander/collect.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"syscall"
 	"time"
 )
 
@@ -91,11 +92,13 @@ func processAlive(pid int) bool {
 	if pid == 0 {
 		return false
 	}
-	process, err := os.FindProcess(pid)
+	// Signal(nil) broken in Go 1.24: pidfd path returns "unsupported signal type".
+	// Signal(syscall.Signal(0)) correctly maps to kill(pid, 0) via pidfd_send_signal.
+	p, err := os.FindProcess(pid)
 	if err != nil {
 		return false
 	}
-	return process.Signal(nil) == nil
+	return p.Signal(syscall.Signal(0)) == nil
 }
 
 // GetUnnotified returns completed/failed operations not yet notified


### PR DESCRIPTION
## Problem
`processAlive` used `os.FindProcess(pid).Signal(nil)` to check if a process is alive.

In Go 1.24, the `os` package switched to `pidfd` for process management on Linux. `Signal(nil)` now returns `"unsupported signal type"` instead of mapping to `kill(pid, 0)`. This meant `processAlive` **always returned false**, causing Scan to mark every active operation as failed after 60 seconds.

## Root Cause
Verified with a test program comparing three methods:

| Method | Process alive | Process dead |
|--------|-------------|-------------|
| `Signal(nil)` | ❌ unsupported signal type | ❌ unsupported signal type |
| `Signal(syscall.Signal(0))` | ✅ nil | ❌ process already finished |
| `syscall.Kill(pid, 0)` | ✅ nil | ❌ no such process |

`Signal(nil)` is broken regardless of process state on Go 1.24.

## Fix
Replace `Signal(nil)` with `Signal(syscall.Signal(0))` — stays within the `os.Process` API, cross-platform compatible, correct behavior.