### PR TITLE
docs: add completion monitoring to SKILL.md

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -60,6 +60,17 @@ check_prereqs() {
         info "Warning: GitHub Copilot CLI not found. Required for running squads."
         info "  npm install -g @githubnext/github-copilot-cli"
     fi
+
+    # Check gh CLI and auth status
+    if command -v gh >/dev/null 2>&1; then
+        if ! gh auth status &>/dev/null; then
+            info "⚠️  GitHub CLI not authenticated. Run before using SWAT:"
+            info "    gh auth login"
+        fi
+    else
+        info "⚠️  GitHub CLI (gh) not found. Required for Copilot CLI auth."
+        info "    Install: https://cli.github.com"
+    fi
 }
 
 # --- Download & Extract ---

--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,13 @@ REPO="LangSensei/swat-v2"
 SWAT_HOME="$HOME/.swat"
 BIN_DIR="$HOME/.local/bin"
 
+# --- Safety: refuse to run as root ---
+if [[ "$(id -u)" -eq 0 ]]; then
+    echo -e "\033[0;31m[swat]\033[0m Do not run this installer as root or with sudo."
+    echo -e "\033[0;31m[swat]\033[0m Run as your normal user:  curl -fsSL ... | bash"
+    exit 1
+fi
+
 info()  { echo -e "\033[0;36m[swat]\033[0m $*"; }
 ok()    { echo -e "\033[0;32m[swat]\033[0m $*"; }
 err()   { echo -e "\033[0;31m[swat]\033[0m $*" >&2; }

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -72,3 +72,9 @@ If SWAT tools are not available, guide the user to install:
 curl -fsSL https://raw.githubusercontent.com/LangSensei/swat-v2/master/install.sh | bash
 ```
 Then restart OpenClaw. After that, install a squad: `swat_install("squad-name")`.
+
+Before the first dispatch, verify GitHub auth is set up (required for Copilot CLI):
+```bash
+gh auth status
+```
+If not authenticated, guide the user to run `gh auth login` first.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -30,6 +30,27 @@ SWAT dispatches tasks to autonomous AI squads powered by GitHub Copilot CLI. Eac
 - `swat_status` returns unnotified completions. Summarize the result to the user.
 - `swat_list` shows all operations if you need the full picture.
 
+## Completion Monitoring
+
+After dispatching one or more tasks, set up a **cron job** to poll for completions:
+
+```
+cron(action=add, job={
+  name: "swat-monitor",
+  schedule: { kind: "every", everyMs: 120000 },
+  sessionTarget: "isolated",
+  payload: {
+    kind: "agentTurn",
+    message: "Call swat_status. If there are unnotified results, summarize each one (operation ID, squad, brief, status, summary) and send to the user. Then call swat_list to mark them seen. If no unnotified results, reply NO_REPLY."
+  },
+  delivery: { mode: "announce" }
+})
+```
+
+- **Auto-delete**: When all dispatched tasks are done (no active operations), delete the cron job.
+- **Don't stack**: Only create one monitor cron at a time. Check if one exists before creating another.
+- **Interval**: 2 minutes is a good default. Adjust if the user wants faster/slower updates.
+
 ## Critical Rules
 
 1. **Fire and forget** — After dispatch, immediately return control to the user. Do not monitor, poll, or block.


### PR DESCRIPTION
Adds a 'Completion Monitoring' section teaching the agent to:
- Set a cron job (every 2 min) after dispatch to poll `swat_status`
- Auto-notify user when operations complete/fail
- Auto-delete cron when no active operations remain
- Avoid stacking multiple monitor crons