### PR TITLE
refactor: remove notified tracking, delegate to OpenClaw

### DIFF
--- a/commander/collect.go
+++ b/commander/collect.go
@@ -1,7 +1,6 @@
 package commander
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -101,22 +100,4 @@ func processAlive(pid int) bool {
 	return p.Signal(syscall.Signal(0)) == nil
 }
 
-// Status returns a summary: counts + active operations
-func (c *Commander) Status() map[string]interface{} {
-	ops, _ := c.ListOperations()
-	counts := map[string]int{"queued": 0, "active": 0, "completed": 0, "failed": 0}
-	var active []*Operation
-	for _, op := range ops {
-		counts[op.Status]++
-		if op.Status == "active" {
-			active = append(active, op)
-		}
-	}
 
-	return map[string]interface{}{
-		"counts":    counts,
-		"active":    active,
-		"iteration": c.Iteration,
-		"message":   fmt.Sprintf("%d queued, %d active, %d completed, %d failed", counts["queued"], counts["active"], counts["completed"], counts["failed"]),
-	}
-}

--- a/commander/collect.go
+++ b/commander/collect.go
@@ -101,44 +101,22 @@ func processAlive(pid int) bool {
 	return p.Signal(syscall.Signal(0)) == nil
 }
 
-// GetUnnotified returns completed/failed operations not yet notified
-func (c *Commander) GetUnnotified() ([]*Operation, error) {
-	ops, err := c.ListOperations()
-	if err != nil {
-		return nil, err
-	}
-	var result []*Operation
-	for _, op := range ops {
-		if (op.Status == "completed" || op.Status == "failed") && !op.Notified {
-			result = append(result, op)
-		}
-	}
-	return result, nil
-}
-
-// MarkNotified sets notified=true for an operation
-func (c *Commander) MarkNotified(opID string) error {
-	op, err := c.findOperation(opID)
-	if err != nil {
-		return err
-	}
-	op.Notified = true
-	return c.SaveOperation(op)
-}
-
-// Status returns a summary of all operations
+// Status returns a summary: counts + active operations
 func (c *Commander) Status() map[string]interface{} {
 	ops, _ := c.ListOperations()
 	counts := map[string]int{"queued": 0, "active": 0, "completed": 0, "failed": 0}
+	var active []*Operation
 	for _, op := range ops {
 		counts[op.Status]++
+		if op.Status == "active" {
+			active = append(active, op)
+		}
 	}
-	unnotified, _ := c.GetUnnotified()
 
 	return map[string]interface{}{
-		"counts":     counts,
-		"unnotified": unnotified,
-		"iteration":  c.Iteration,
-		"message":    fmt.Sprintf("%d queued, %d active, %d completed, %d failed", counts["queued"], counts["active"], counts["completed"], counts["failed"]),
+		"counts":    counts,
+		"active":    active,
+		"iteration": c.Iteration,
+		"message":   fmt.Sprintf("%d queued, %d active, %d completed, %d failed", counts["queued"], counts["active"], counts["completed"], counts["failed"]),
 	}
 }

--- a/commander/commander.go
+++ b/commander/commander.go
@@ -18,7 +18,6 @@ type Operation struct {
 	Details       string     `json:"details,omitempty"`
 	Status        string     `json:"status"`
 	PID           int        `json:"pid,omitempty"`
-	Notified      bool       `json:"notified"`
 	RetryCount    int        `json:"retry_count"`
 	Source        string     `json:"source"`
 	CreatedAt     time.Time  `json:"created_at"`
@@ -148,7 +147,6 @@ func buildOperationFile(op *Operation) string {
 	sb.WriteString(fmt.Sprintf("status: %s\n", op.Status))
 	sb.WriteString(fmt.Sprintf("source: %s\n", op.Source))
 	sb.WriteString(fmt.Sprintf("pid: %d\n", op.PID))
-	sb.WriteString(fmt.Sprintf("notified: %v\n", op.Notified))
 	sb.WriteString(fmt.Sprintf("retry_count: %d\n", op.RetryCount))
 	sb.WriteString(fmt.Sprintf("created_at: %s\n", op.CreatedAt.Format(time.RFC3339)))
 	writeOptionalTime(&sb, "dispatched_at", op.DispatchedAt)
@@ -225,7 +223,7 @@ func parseOperationMD(content string) (*Operation, error) {
 		case "pid":
 			fmt.Sscanf(val, "%d", &op.PID)
 		case "notified":
-			op.Notified = val == "true"
+			// legacy field, ignored
 		case "retry_count":
 			fmt.Sscanf(val, "%d", &op.RetryCount)
 		case "created_at":

--- a/commander/commander.go
+++ b/commander/commander.go
@@ -222,8 +222,6 @@ func parseOperationMD(content string) (*Operation, error) {
 			op.Source = val
 		case "pid":
 			fmt.Sscanf(val, "%d", &op.PID)
-		case "notified":
-			// legacy field, ignored
 		case "retry_count":
 			fmt.Sscanf(val, "%d", &op.RetryCount)
 		case "created_at":

--- a/install.sh
+++ b/install.sh
@@ -58,7 +58,7 @@ check_prereqs() {
 
     if ! command -v copilot >/dev/null 2>&1; then
         info "Warning: GitHub Copilot CLI not found. Required for running squads."
-        info "  npm install -g @githubnext/github-copilot-cli"
+        info "  npm install -g @github/copilot"
     fi
 
     # Check gh CLI and auth status

--- a/mcp/handlers.go
+++ b/mcp/handlers.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/LangSensei/swat/commander"
@@ -213,6 +214,29 @@ func (s *Server) handleList(args map[string]interface{}) toolResult {
 		}
 	}
 
+	// Sort by time descending (most recent first)
+	sort.Slice(ops, func(i, j int) bool {
+		return opSortTime(ops[i]).After(opSortTime(ops[j]))
+	})
+
+	// Pagination: offset then limit (default limit=50)
+	offset := 0
+	if v, ok := args["offset"].(float64); ok && int(v) > 0 {
+		offset = int(v)
+	}
+	limit := 50
+	if v, ok := args["limit"].(float64); ok && int(v) > 0 {
+		limit = int(v)
+	}
+	if offset > len(ops) {
+		ops = nil
+	} else {
+		ops = ops[offset:]
+		if limit < len(ops) {
+			ops = ops[:limit]
+		}
+	}
+
 	result := map[string]interface{}{
 		"counts":     counts,
 		"operations": ops,
@@ -221,6 +245,20 @@ func (s *Server) handleList(args map[string]interface{}) toolResult {
 	return toolResult{
 		Content: []contentBlock{{Type: "text", Text: string(data)}},
 	}
+}
+
+// opSortTime returns the most relevant timestamp for sorting (newest event first)
+func opSortTime(op *commander.Operation) time.Time {
+	if op.CompletedAt != nil {
+		return *op.CompletedAt
+	}
+	if op.FailedAt != nil {
+		return *op.FailedAt
+	}
+	if op.DispatchedAt != nil {
+		return *op.DispatchedAt
+	}
+	return op.CreatedAt
 }
 
 func (s *Server) handleCancel(args map[string]interface{}) toolResult {

--- a/mcp/handlers.go
+++ b/mcp/handlers.go
@@ -128,8 +128,6 @@ func (s *Server) handleToolCall(params callToolParams) toolResult {
 	switch params.Name {
 	case "swat_dispatch":
 		return s.handleDispatch(params.Arguments)
-	case "swat_status":
-		return s.handleStatus(params.Arguments)
 	case "swat_list":
 		return s.handleList(params.Arguments)
 	case "swat_cancel":
@@ -171,14 +169,6 @@ func (s *Server) handleDispatch(args map[string]interface{}) toolResult {
 	}
 }
 
-func (s *Server) handleStatus(args map[string]interface{}) toolResult {
-	status := s.Commander.Status()
-	data, _ := json.MarshalIndent(status, "", "  ")
-	return toolResult{
-		Content: []contentBlock{{Type: "text", Text: string(data)}},
-	}
-}
-
 func (s *Server) handleList(args map[string]interface{}) toolResult {
 	ops, err := s.Commander.ListOperations()
 	if err != nil {
@@ -186,6 +176,12 @@ func (s *Server) handleList(args map[string]interface{}) toolResult {
 			Content: []contentBlock{{Type: "text", Text: fmt.Sprintf("list failed: %v", err)}},
 			IsError: true,
 		}
+	}
+
+	// Compute counts before filtering
+	counts := map[string]int{"queued": 0, "active": 0, "completed": 0, "failed": 0}
+	for _, op := range ops {
+		counts[op.Status]++
 	}
 
 	statusFilter, _ := args["status"].(string)
@@ -217,7 +213,11 @@ func (s *Server) handleList(args map[string]interface{}) toolResult {
 		}
 	}
 
-	data, _ := json.MarshalIndent(ops, "", "  ")
+	result := map[string]interface{}{
+		"counts":     counts,
+		"operations": ops,
+	}
+	data, _ := json.MarshalIndent(result, "", "  ")
 	return toolResult{
 		Content: []contentBlock{{Type: "text", Text: string(data)}},
 	}

--- a/mcp/handlers.go
+++ b/mcp/handlers.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"time"
 
 	"github.com/LangSensei/swat/commander"
 )
@@ -196,6 +197,24 @@ func (s *Server) handleList(args map[string]interface{}) toolResult {
 			}
 		}
 		ops = filtered
+	}
+
+	// Filter by time: only return ops with completed_at or failed_at after "since"
+	sinceStr, _ := args["since"].(string)
+	if sinceStr != "" {
+		if sinceTime, err := time.Parse(time.RFC3339, sinceStr); err == nil {
+			var filtered []*commander.Operation
+			for _, op := range ops {
+				if op.CompletedAt != nil && op.CompletedAt.After(sinceTime) {
+					filtered = append(filtered, op)
+				} else if op.FailedAt != nil && op.FailedAt.After(sinceTime) {
+					filtered = append(filtered, op)
+				} else if op.Status == "active" || op.Status == "queued" {
+					filtered = append(filtered, op) // always include in-flight
+				}
+			}
+			ops = filtered
+		}
 	}
 
 	data, _ := json.MarshalIndent(ops, "", "  ")

--- a/mcp/mcp.go
+++ b/mcp/mcp.go
@@ -45,6 +45,8 @@ func (s *Server) Tools() []ToolDef {
 				"properties": map[string]interface{}{
 					"status": map[string]interface{}{"type": "string", "description": "Filter by status (queued/active/completed/failed)"},
 					"since":  map[string]interface{}{"type": "string", "description": "Only return terminal ops after this RFC3339 timestamp"},
+					"limit":  map[string]interface{}{"type": "integer", "description": "Max results to return (default 50)"},
+					"offset": map[string]interface{}{"type": "integer", "description": "Skip first N results (default 0)"},
 				},
 			},
 		},

--- a/mcp/mcp.go
+++ b/mcp/mcp.go
@@ -39,7 +39,7 @@ func (s *Server) Tools() []ToolDef {
 		},
 		{
 			Name:        "swat_status",
-			Description: "Get SWAT task status and unnotified completions",
+			Description: "Get SWAT task status and active operations",
 			InputSchema: map[string]interface{}{
 				"type":       "object",
 				"properties": map[string]interface{}{},
@@ -52,6 +52,7 @@ func (s *Server) Tools() []ToolDef {
 				"type": "object",
 				"properties": map[string]interface{}{
 					"status": map[string]interface{}{"type": "string", "description": "Filter by status (queued/active/completed/failed)"},
+					"since":  map[string]interface{}{"type": "string", "description": "Only return terminal ops after this RFC3339 timestamp"},
 				},
 			},
 		},

--- a/mcp/mcp.go
+++ b/mcp/mcp.go
@@ -38,16 +38,8 @@ func (s *Server) Tools() []ToolDef {
 			},
 		},
 		{
-			Name:        "swat_status",
-			Description: "Get SWAT task status and active operations",
-			InputSchema: map[string]interface{}{
-				"type":       "object",
-				"properties": map[string]interface{}{},
-			},
-		},
-		{
 			Name:        "swat_list",
-			Description: "List all SWAT operations",
+			Description: "List SWAT operations with optional filters. Returns counts and matching operations.",
 			InputSchema: map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -36,6 +36,8 @@ const TOOLS = [
     parameters: Type.Object({
       status: Type.Optional(Type.String({ description: "Filter by status (queued/active/completed/failed)" })),
       since: Type.Optional(Type.String({ description: "Only return terminal ops after this RFC3339 timestamp" })),
+      limit: Type.Optional(Type.Number({ description: "Max results to return (default 50)" })),
+      offset: Type.Optional(Type.Number({ description: "Skip first N results (default 0)" })),
     }),
   },
   {

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -30,17 +30,12 @@ const TOOLS = [
     }),
   },
   {
-    name: "swat_status",
-    label: "SWAT Status",
-    description: "Get SWAT task status and unnotified completions",
-    parameters: Type.Object({}),
-  },
-  {
     name: "swat_list",
     label: "SWAT List",
-    description: "List all SWAT operations",
+    description: "List SWAT operations with optional filters. Returns counts and matching operations.",
     parameters: Type.Object({
       status: Type.Optional(Type.String({ description: "Filter by status (queued/active/completed/failed)" })),
+      since: Type.Optional(Type.String({ description: "Only return terminal ops after this RFC3339 timestamp" })),
     }),
   },
   {

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -7,9 +7,8 @@ SWAT dispatches tasks to autonomous AI squads powered by GitHub Copilot CLI. Eac
 | Tool | Purpose |
 |---|---|
 | `swat_dispatch` | Send a task to a squad |
-| `swat_status` | Check active operations and task counts |
+| `swat_list` | List operations (supports status/since filters), returns counts |
 | `swat_squads` | List installed squads |
-| `swat_list` | List all operations (supports status and since filters) |
 | `swat_cancel` | Cancel a running operation |
 | `swat_schedule` | Create a scheduled/recurring task |
 | `swat_browse` | List squads available in the marketplace |
@@ -25,10 +24,9 @@ SWAT dispatches tasks to autonomous AI squads powered by GitHub Copilot CLI. Eac
 
 ## Checking Results
 
-- Call `swat_status` **only when the user asks** about a task, or when you have a natural reason to check (e.g., heartbeat).
+- Call `swat_list` **only when the user asks** about a task, or when you have a natural reason to check (e.g., heartbeat).
 - **Never** use `sleep`, polling loops, or repeated `exec` calls to wait for completion. This blocks the main session and makes you unresponsive.
-- `swat_status` returns counts + currently active operations.
-- `swat_list` shows all operations. Use `status` and `since` filters to narrow results.
+- `swat_list` returns counts + operations. Use `status` and `since` filters to narrow results.
 
 ## Completion Monitoring (Active-Diff Pattern)
 
@@ -41,7 +39,7 @@ cron(action=add, job={
   sessionTarget: "isolated",
   payload: {
     kind: "agentTurn",
-    message: "You are a SWAT completion monitor. Follow these steps exactly:\n\n1. Read workspace file memory/swat-monitor.json. If it doesn't exist, treat lastActiveIds as [].\n2. Call swat_status to get current active operation IDs.\n3. Compute disappeared = IDs in lastActiveIds that are NOT in current active IDs.\n4. For each disappeared ID, call swat_list(status=completed) or swat_list(status=failed) to find its details. Send a summary to the user (operation ID, squad, brief, status, summary).\n5. Write memory/swat-monitor.json with lastActiveIds = current active IDs.\n6. If current active count is 0 AND no disappeared IDs, delete this cron job.\n7. If nothing to report, reply NO_REPLY."
+    message: "You are a SWAT completion monitor. Follow these steps exactly:\n\n1. Read workspace file memory/swat-monitor.json. If it doesn't exist, treat lastActiveIds as [].\n2. Call swat_list(status=active) to get current active operation IDs.\n3. Compute disappeared = IDs in lastActiveIds that are NOT in current active IDs.\n4. For each disappeared ID, call swat_list to find its details (it will be completed or failed). Send a summary to the user (operation ID, squad, brief, status, summary).\n5. Write memory/swat-monitor.json with lastActiveIds = current active IDs.\n6. If current active count is 0 AND no disappeared IDs, delete this cron job.\n7. If nothing to report, reply NO_REPLY."
   },
   delivery: { mode: "announce" }
 })

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -29,6 +29,9 @@ SWAT dispatches tasks to autonomous AI squads powered by GitHub Copilot CLI. Eac
 - `swat_list` returns counts + operations. Filters:
   - `status` — `queued`, `active`, `completed`, `failed`
   - `since` — RFC3339 timestamp (e.g. `2026-03-09T04:00:00Z`), only returns terminal ops after this time; active/queued always included
+  - `limit` — max results (default 50)
+  - `offset` — skip first N results (default 0)
+  - Results sorted by time descending (most recent first)
 
 ## Completion Monitoring (Active-Diff Pattern)
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -7,9 +7,9 @@ SWAT dispatches tasks to autonomous AI squads powered by GitHub Copilot CLI. Eac
 | Tool | Purpose |
 |---|---|
 | `swat_dispatch` | Send a task to a squad |
-| `swat_status` | Check for completions and unnotified results |
+| `swat_status` | Check active operations and task counts |
 | `swat_squads` | List installed squads |
-| `swat_list` | List all operations with status |
+| `swat_list` | List all operations (supports status and since filters) |
 | `swat_cancel` | Cancel a running operation |
 | `swat_schedule` | Create a scheduled/recurring task |
 | `swat_browse` | List squads available in the marketplace |
@@ -27,12 +27,12 @@ SWAT dispatches tasks to autonomous AI squads powered by GitHub Copilot CLI. Eac
 
 - Call `swat_status` **only when the user asks** about a task, or when you have a natural reason to check (e.g., heartbeat).
 - **Never** use `sleep`, polling loops, or repeated `exec` calls to wait for completion. This blocks the main session and makes you unresponsive.
-- `swat_status` returns unnotified completions. Summarize the result to the user.
-- `swat_list` shows all operations if you need the full picture.
+- `swat_status` returns counts + currently active operations.
+- `swat_list` shows all operations. Use `status` and `since` filters to narrow results.
 
-## Completion Monitoring
+## Completion Monitoring (Active-Diff Pattern)
 
-After dispatching one or more tasks, set up a **cron job** to poll for completions:
+After dispatching one or more tasks, set up a **cron job** to detect completions via active-list diffing:
 
 ```
 cron(action=add, job={
@@ -41,13 +41,13 @@ cron(action=add, job={
   sessionTarget: "isolated",
   payload: {
     kind: "agentTurn",
-    message: "Call swat_status. If there are unnotified results, summarize each one (operation ID, squad, brief, status, summary) and send to the user. Then call swat_list to mark them seen. If no unnotified results, reply NO_REPLY."
+    message: "You are a SWAT completion monitor. Follow these steps exactly:\n\n1. Read workspace file memory/swat-monitor.json. If it doesn't exist, treat lastActiveIds as [].\n2. Call swat_status to get current active operation IDs.\n3. Compute disappeared = IDs in lastActiveIds that are NOT in current active IDs.\n4. For each disappeared ID, call swat_list(status=completed) or swat_list(status=failed) to find its details. Send a summary to the user (operation ID, squad, brief, status, summary).\n5. Write memory/swat-monitor.json with lastActiveIds = current active IDs.\n6. If current active count is 0 AND no disappeared IDs, delete this cron job.\n7. If nothing to report, reply NO_REPLY."
   },
   delivery: { mode: "announce" }
 })
 ```
 
-- **Auto-delete**: When all dispatched tasks are done (no active operations), delete the cron job.
+- **Auto-delete**: When active=0 and no new completions detected, the cron deletes itself.
 - **Don't stack**: Only create one monitor cron at a time. Check if one exists before creating another.
 - **Interval**: 2 minutes is a good default. Adjust if the user wants faster/slower updates.
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -26,7 +26,9 @@ SWAT dispatches tasks to autonomous AI squads powered by GitHub Copilot CLI. Eac
 
 - Call `swat_list` **only when the user asks** about a task, or when you have a natural reason to check (e.g., heartbeat).
 - **Never** use `sleep`, polling loops, or repeated `exec` calls to wait for completion. This blocks the main session and makes you unresponsive.
-- `swat_list` returns counts + operations. Use `status` and `since` filters to narrow results.
+- `swat_list` returns counts + operations. Filters:
+  - `status` — `queued`, `active`, `completed`, `failed`
+  - `since` — RFC3339 timestamp (e.g. `2026-03-09T04:00:00Z`), only returns terminal ops after this time; active/queued always included
 
 ## Completion Monitoring (Active-Diff Pattern)
 


### PR DESCRIPTION
## Changes

- Remove `Notified` field from Operation struct and OPERATION.md serialization
- Remove `GetUnnotified()` and `MarkNotified()` from Commander
- `Status()` now returns counts + active ops list (no unnotified)
- `swat_list` supports `since` param (RFC3339) to filter terminal ops by time
- Legacy `notified` field in existing OPERATION.md files is silently ignored

## Design: Active-Diff Monitoring

Notification tracking is now OpenClaw's responsibility:

1. Cron reads `lastActiveIds` from state file
2. Calls `swat_status` → gets current active IDs
3. Diff: IDs in lastActiveIds but not in current = disappeared (completed/failed)
4. For disappeared IDs, calls `swat_list` to get details
5. Notifies user
6. Updates `lastActiveIds`
7. When active=0 and no disappeared → deletes cron

Benefits:
- No race conditions (set diff, not timestamps)
- SWAT stays pure data manager, OpenClaw handles notification orchestration
- Clean separation of concerns