### PR TITLE
refactor: rename tools for clarity + add swat_squad_update

### DIFF
--- a/commander/marketplace.go
+++ b/commander/marketplace.go
@@ -103,6 +103,50 @@ func (c *Commander) Install(squad string) error {
 	return nil
 }
 
+// Update re-downloads a squad and its dependencies from the marketplace
+func (c *Commander) Update(squad string) error {
+	bpDir := filepath.Join(c.SwatRoot, "blueprints")
+	squadDir := filepath.Join(bpDir, "squads", squad)
+
+	if !fileExists(filepath.Join(squadDir, "MANIFEST.md")) {
+		return fmt.Errorf("squad %q is not installed", squad)
+	}
+
+	// Re-download squad (overwrite existing)
+	if err := os.RemoveAll(squadDir); err != nil {
+		return fmt.Errorf("remove old squad %q: %w", squad, err)
+	}
+	if err := ghDownloadDir("squads/"+squad, squadDir); err != nil {
+		return fmt.Errorf("download squad %q: %w", squad, err)
+	}
+
+	// Resolve and update all dependencies
+	allSkills := c.resolveDependencies(squad)
+	allMCPs := c.resolveMCPDependencies(squad)
+
+	for _, skill := range allSkills {
+		destSkill := filepath.Join(bpDir, "skills", skill)
+		os.RemoveAll(destSkill) // remove old version
+		if err := ghDownloadDir("skills/"+skill, destSkill); err != nil {
+			return fmt.Errorf("download skill %q: %w", skill, err)
+		}
+	}
+
+	for _, mcp := range allMCPs {
+		destMCP := filepath.Join(bpDir, "mcps", mcp+".json")
+		data, err := ghGetFile("mcps/" + mcp + ".json")
+		if err != nil {
+			return fmt.Errorf("download MCP %q: %w", mcp, err)
+		}
+		os.MkdirAll(filepath.Join(bpDir, "mcps"), 0755)
+		if err := os.WriteFile(destMCP, data, 0644); err != nil {
+			return fmt.Errorf("write MCP %q: %w", mcp, err)
+		}
+	}
+
+	return nil
+}
+
 // Uninstall removes a squad blueprint and cleans up orphaned dependencies
 func (c *Commander) Uninstall(squad string, purge bool) error {
 	bpDir := filepath.Join(c.SwatRoot, "blueprints")

--- a/mcp/handlers.go
+++ b/mcp/handlers.go
@@ -129,7 +129,7 @@ func (s *Server) handleToolCall(params callToolParams) toolResult {
 	switch params.Name {
 	case "swat_dispatch":
 		return s.handleDispatch(params.Arguments)
-	case "swat_list":
+	case "swat_ops":
 		return s.handleList(params.Arguments)
 	case "swat_cancel":
 		return s.handleCancel(params.Arguments)
@@ -137,12 +137,14 @@ func (s *Server) handleToolCall(params callToolParams) toolResult {
 		return s.handleSquads(params.Arguments)
 	case "swat_schedule":
 		return s.handleSchedule(params.Arguments)
-	case "swat_install":
+	case "swat_squad_install":
 		return s.handleInstall(params.Arguments)
-	case "swat_uninstall":
+	case "swat_squad_uninstall":
 		return s.handleUninstall(params.Arguments)
-	case "swat_browse":
+	case "swat_squad_browse":
 		return s.handleBrowse(params.Arguments)
+	case "swat_squad_update":
+		return s.handleUpdate(params.Arguments)
 	default:
 		return toolResult{
 			Content: []contentBlock{{Type: "text", Text: fmt.Sprintf("unknown tool: %s", params.Name)}},
@@ -372,6 +374,27 @@ func (s *Server) handleBrowse(args map[string]interface{}) toolResult {
 	data, _ := json.MarshalIndent(results, "", "  ")
 	return toolResult{
 		Content: []contentBlock{{Type: "text", Text: string(data)}},
+	}
+}
+
+func (s *Server) handleUpdate(args map[string]interface{}) toolResult {
+	squad, _ := args["squad"].(string)
+	if squad == "" {
+		return toolResult{
+			Content: []contentBlock{{Type: "text", Text: "squad name is required"}},
+			IsError: true,
+		}
+	}
+
+	if err := s.Commander.Update(squad); err != nil {
+		return toolResult{
+			Content: []contentBlock{{Type: "text", Text: fmt.Sprintf("update failed: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	return toolResult{
+		Content: []contentBlock{{Type: "text", Text: fmt.Sprintf("squad %q updated to latest version", squad)}},
 	}
 }
 

--- a/mcp/mcp.go
+++ b/mcp/mcp.go
@@ -38,7 +38,7 @@ func (s *Server) Tools() []ToolDef {
 			},
 		},
 		{
-			Name:        "swat_list",
+			Name:        "swat_ops",
 			Description: "List SWAT operations with optional filters. Returns counts and matching operations.",
 			InputSchema: map[string]interface{}{
 				"type": "object",
@@ -84,7 +84,15 @@ func (s *Server) Tools() []ToolDef {
 			},
 		},
 		{
-			Name:        "swat_install",
+			Name:        "swat_squad_browse",
+			Description: "List all squads available in the marketplace with install status",
+			InputSchema: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+			},
+		},
+		{
+			Name:        "swat_squad_install",
 			Description: "Install a squad from the SWAT marketplace (auto-resolves skill and MCP dependencies)",
 			InputSchema: map[string]interface{}{
 				"type": "object",
@@ -95,7 +103,7 @@ func (s *Server) Tools() []ToolDef {
 			},
 		},
 		{
-			Name:        "swat_uninstall",
+			Name:        "swat_squad_uninstall",
 			Description: "Uninstall a squad and clean up orphaned dependencies",
 			InputSchema: map[string]interface{}{
 				"type": "object",
@@ -107,11 +115,14 @@ func (s *Server) Tools() []ToolDef {
 			},
 		},
 		{
-			Name:        "swat_browse",
-			Description: "List all squads available in the marketplace with install status",
+			Name:        "swat_squad_update",
+			Description: "Update an installed squad to the latest marketplace version",
 			InputSchema: map[string]interface{}{
-				"type":       "object",
-				"properties": map[string]interface{}{},
+				"type": "object",
+				"properties": map[string]interface{}{
+					"squad": map[string]interface{}{"type": "string", "description": "Squad name to update"},
+				},
+				"required": []string{"squad"},
 			},
 		},
 	}

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -30,8 +30,8 @@ const TOOLS = [
     }),
   },
   {
-    name: "swat_list",
-    label: "SWAT List",
+    name: "swat_ops",
+    label: "SWAT Operations",
     description: "List SWAT operations with optional filters. Returns counts and matching operations.",
     parameters: Type.Object({
       status: Type.Optional(Type.String({ description: "Filter by status (queued/active/completed/failed)" })),
@@ -66,26 +66,34 @@ const TOOLS = [
     }),
   },
   {
-    name: "swat_browse",
-    label: "SWAT Browse",
+    name: "swat_squad_browse",
+    label: "SWAT Squad Browse",
     description: "List all squads available in the marketplace",
     parameters: Type.Object({}),
   },
   {
-    name: "swat_install",
-    label: "SWAT Install",
+    name: "swat_squad_install",
+    label: "SWAT Squad Install",
     description: "Install a squad from the marketplace",
     parameters: Type.Object({
       squad: Type.String({ description: "Squad name to install" }),
     }),
   },
   {
-    name: "swat_uninstall",
-    label: "SWAT Uninstall",
+    name: "swat_squad_uninstall",
+    label: "SWAT Squad Uninstall",
     description: "Uninstall a squad and clean up orphaned dependencies",
     parameters: Type.Object({
       squad: Type.String({ description: "Squad name to uninstall" }),
       purge: Type.Optional(Type.Boolean({ description: "Also delete runtime data (default: false)" })),
+    }),
+  },
+  {
+    name: "swat_squad_update",
+    label: "SWAT Squad Update",
+    description: "Update an installed squad to the latest marketplace version",
+    parameters: Type.Object({
+      squad: Type.String({ description: "Squad name to update" }),
     }),
   },
 ];

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -4,29 +4,39 @@ SWAT dispatches tasks to autonomous AI squads powered by GitHub Copilot CLI. Eac
 
 ## Tools
 
+### Operations
 | Tool | Purpose |
 |---|---|
 | `swat_dispatch` | Send a task to a squad |
-| `swat_list` | List operations (supports status/since filters), returns counts |
-| `swat_squads` | List installed squads |
+| `swat_ops` | List operations (supports status/since/limit/offset filters), returns counts |
 | `swat_cancel` | Cancel a running operation |
+
+### Squads
+| Tool | Purpose |
+|---|---|
+| `swat_squads` | List installed squads |
+| `swat_squad_browse` | List squads available in the marketplace |
+| `swat_squad_install` | Install a squad from the marketplace |
+| `swat_squad_uninstall` | Uninstall a squad and clean up dependencies |
+| `swat_squad_update` | Update an installed squad to the latest version |
+
+### Schedule
+| Tool | Purpose |
+|---|---|
 | `swat_schedule` | Create a scheduled/recurring task |
-| `swat_browse` | List squads available in the marketplace |
-| `swat_install` | Install a squad from the marketplace |
-| `swat_uninstall` | Uninstall a squad and clean up dependencies |
 
 ## How to Dispatch
 
-1. **Pick a squad** — Call `swat_squads` to see installed squads. If none fit, use `swat_browse` + `swat_install`.
+1. **Pick a squad** — Call `swat_squads` to see installed squads. If none fit, use `swat_squad_browse` + `swat_squad_install`.
 2. **Dispatch** — `swat_dispatch(brief, squad)`. Returns an operation ID immediately.
 3. **Tell the user** — Confirm the task is dispatched and which squad is on it.
 4. **Move on** — Do NOT wait, poll, or sleep. The squad works in the background.
 
 ## Checking Results
 
-- Call `swat_list` **only when the user asks** about a task, or when you have a natural reason to check (e.g., heartbeat).
+- Call `swat_ops` **only when the user asks** about a task, or when you have a natural reason to check (e.g., heartbeat).
 - **Never** use `sleep`, polling loops, or repeated `exec` calls to wait for completion. This blocks the main session and makes you unresponsive.
-- `swat_list` returns counts + operations. Filters:
+- `swat_ops` returns counts + operations. Filters:
   - `status` — `queued`, `active`, `completed`, `failed`
   - `since` — RFC3339 timestamp (e.g. `2026-03-09T04:00:00Z`), only returns terminal ops after this time; active/queued always included
   - `limit` — max results (default 50)
@@ -44,7 +54,7 @@ cron(action=add, job={
   sessionTarget: "isolated",
   payload: {
     kind: "agentTurn",
-    message: "You are a SWAT completion monitor. Follow these steps exactly:\n\n1. Read workspace file memory/swat-monitor.json. If it doesn't exist, treat lastActiveIds as [].\n2. Call swat_list(status=active) to get current active operation IDs.\n3. Compute disappeared = IDs in lastActiveIds that are NOT in current active IDs.\n4. For each disappeared ID, call swat_list to find its details (it will be completed or failed). Send a summary to the user (operation ID, squad, brief, status, summary).\n5. Write memory/swat-monitor.json with lastActiveIds = current active IDs.\n6. If current active count is 0 AND no disappeared IDs, delete this cron job.\n7. If nothing to report, reply NO_REPLY."
+    message: "You are a SWAT completion monitor. Follow these steps exactly:\n\n1. Read workspace file memory/swat-monitor.json. If it doesn't exist, treat lastActiveIds as [].\n2. Call swat_ops(status=active) to get current active operation IDs.\n3. Compute disappeared = IDs in lastActiveIds that are NOT in current active IDs.\n4. For each disappeared ID, call swat_ops to find its details (it will be completed or failed). Send a summary to the user (operation ID, squad, brief, status, summary).\n5. Write memory/swat-monitor.json with lastActiveIds = current active IDs.\n6. If current active count is 0 AND no disappeared IDs, delete this cron job.\n7. If nothing to report, reply NO_REPLY."
   },
   delivery: { mode: "announce" }
 })
@@ -64,9 +74,10 @@ cron(action=add, job={
 
 ## Marketplace
 
-- `swat_browse` — See what's available to install (fetches from GitHub, no clone needed).
-- `swat_install(squad)` — Downloads squad + resolves dependencies automatically.
-- `swat_uninstall(squad)` — Removes squad blueprint + cleans up orphaned dependencies.
+- `swat_squad_browse` — See what's available to install (fetches from GitHub, no clone needed).
+- `swat_squad_install(squad)` — Downloads squad + resolves dependencies automatically.
+- `swat_squad_uninstall(squad)` — Removes squad blueprint + cleans up orphaned dependencies.
+- `swat_squad_update(squad)` — Re-downloads squad + dependencies to latest version.
 
 ## First Run
 
@@ -74,7 +85,7 @@ If SWAT tools are not available, guide the user to install:
 ```
 curl -fsSL https://raw.githubusercontent.com/LangSensei/swat-v2/master/install.sh | bash
 ```
-Then restart OpenClaw. After that, install a squad: `swat_install("squad-name")`.
+Then restart OpenClaw. After that, install a squad: `swat_squad_install("squad-name")`.
 
 Before the first dispatch, verify GitHub auth is set up (required for Copilot CLI):
 ```bash


### PR DESCRIPTION
## Changes

### Tool Renames (clearer hierarchy)
- `swat_list` → `swat_ops` (operations)
- `swat_browse` → `swat_squad_browse`
- `swat_install` → `swat_squad_install`
- `swat_uninstall` → `swat_squad_uninstall`

### New Tool
- `swat_squad_update` — re-downloads squad + all dependencies from marketplace

### Final 9 Tools

**Operations (3):** `swat_dispatch`, `swat_ops`, `swat_cancel`
**Squads (5):** `swat_squads`, `swat_squad_browse`, `swat_squad_install`, `swat_squad_uninstall`, `swat_squad_update`
**Schedule (1):** `swat_schedule`

### Files Changed
- `commander/marketplace.go` — new `Update()` method
- `mcp/mcp.go` — tool definitions renamed + added
- `mcp/handlers.go` — routing updated + `handleUpdate` added
- `plugin/index.ts` — tool names synced
- `skill/SKILL.md` — docs updated with grouped tool tables