### PR TITLE
feat: inject Output Schema from MANIFEST into OPERATION.md

### DIFF
--- a/blueprints/OPERATION.md
+++ b/blueprints/OPERATION.md
@@ -28,8 +28,7 @@ summary:
 # UTC timestamp when operation completed successfully
 completed_at:
 # Squad-specific output fields
-# Commander appends fields from the squad's MANIFEST.md Output Schema below this line.
-# Captain fills them during the operation.
+{OUTPUT_SCHEMA}
 ---
 
 # {BRIEF}

--- a/blueprints/squads/_framework/TEMPLATE.md
+++ b/blueprints/squads/_framework/TEMPLATE.md
@@ -1,0 +1,35 @@
+---
+name: {squad-name}                 # kebab-case identifier, matches folder name
+version: "1.0.0"
+description: {one-liner description}
+dependencies:                      # omit block if no dependencies
+  skills: [{skill-names}]
+  mcps: [{mcp-names}]
+---
+
+# {Squad Name} Squad               <!-- display name, can differ from frontmatter name -->
+
+## Domain
+{Detailed scope — what operations, services, or codebases this squad handles.}
+
+## Boundary
+
+**In scope:**
+- {capability 1}
+- {capability 2}
+
+**Out of scope:**
+- {exclusion 1}
+- {exclusion 2}
+
+## Write Access
+- {paths the squad can write to, or "(none — all interactions via API)" if API-only}
+
+## Squad Playbook
+{Domain knowledge, API endpoints, workflows, operational guidance. Use ### subsections to organize content — do not create additional ## sections.}
+
+## Output Schema
+Captain must fill these frontmatter fields in `OPERATION.md` during the operation:
+```yaml
+{field}: # {description}
+```

--- a/commander/compose.go
+++ b/commander/compose.go
@@ -210,3 +210,57 @@ func stripFrontmatter(md string) string {
 	}
 	return strings.TrimLeft(md[end+6:], "\n")
 }
+
+// extractOutputSchema extracts YAML fields from the ## Output Schema section of a MANIFEST.md
+// It looks for the yaml code block and returns the field lines (without the ```yaml wrapper)
+func extractOutputSchema(manifest string) string {
+	body := stripFrontmatter(manifest)
+
+	// Find ## Output Schema section
+	idx := strings.Index(body, "## Output Schema")
+	if idx < 0 {
+		return ""
+	}
+	section := body[idx:]
+
+	// Find yaml code block
+	codeStart := strings.Index(section, "```yaml")
+	if codeStart < 0 {
+		return ""
+	}
+	afterOpen := section[codeStart+7:]
+
+	codeEnd := strings.Index(afterOpen, "```")
+	if codeEnd < 0 {
+		return ""
+	}
+
+	return strings.TrimSpace(afterOpen[:codeEnd])
+}
+
+// injectOutputSchema reads the squad MANIFEST, extracts Output Schema fields,
+// and replaces the {SQUAD_OUTPUT_SCHEMA} placeholder in OPERATION.md
+func (c *Commander) injectOutputSchema(squad string, opDir string) error {
+	manifestPath := filepath.Join(c.SwatRoot, "blueprints", "squads", squad, "MANIFEST.md")
+	manifest, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("read manifest: %w", err)
+	}
+
+	schema := extractOutputSchema(string(manifest))
+
+	opMDPath := filepath.Join(opDir, "OPERATION.md")
+	content, err := os.ReadFile(opMDPath)
+	if err != nil {
+		return fmt.Errorf("read OPERATION.md: %w", err)
+	}
+
+	placeholder := "{OUTPUT_SCHEMA}"
+	contentStr := string(content)
+	if !strings.Contains(contentStr, placeholder) {
+		return nil
+	}
+
+	replaced := strings.Replace(contentStr, placeholder, schema, 1)
+	return os.WriteFile(opMDPath, []byte(replaced), 0644)
+}

--- a/commander/dispatch.go
+++ b/commander/dispatch.go
@@ -105,6 +105,12 @@ func (c *Commander) processOperation(op *Operation) {
 		return
 	}
 
+	// Inject Output Schema from MANIFEST into OPERATION.md
+	if err := c.injectOutputSchema(reloaded.Squad, destDir); err != nil {
+		c.failOperation(reloaded, fmt.Sprintf("inject output schema: %v", err))
+		return
+	}
+
 	// Provision and launch
 	if err := c.provision(reloaded, destDir); err != nil {
 		c.failOperation(reloaded, fmt.Sprintf("provision: %v", err))


### PR DESCRIPTION
## What
Auto-inject squad-specific output fields from MANIFEST.md into OPERATION.md during the dispatch pipeline.

## Why
OPERATION.md template has a placeholder for squad-specific output fields, but they were never actually injected from the squad's MANIFEST.

## Changes
- `commander/compose.go`: `extractOutputSchema()` parses yaml code block from `## Output Schema` section; `injectOutputSchema()` inserts fields after marker comment
- `commander/dispatch.go`: calls `injectOutputSchema()` after classify+move, before provision+launch

## How to Test
Dispatch a task to a squad with Output Schema defined. Check OPERATION.md frontmatter contains the squad's custom fields.