### PR TITLE
feat: add --mcp-only flag to disable commander loop

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"os"
 	"time"
 
 	"github.com/LangSensei/swat/commander"
@@ -9,10 +10,16 @@ import (
 )
 
 func main() {
-	cmdr := commander.New("~/.swat")
-	go cmdr.BackgroundLoop(60 * time.Second)
+	mcpOnly := len(os.Args) > 1 && os.Args[1] == "--mcp-only"
 
-	log.Println("SWAT Commander starting...")
+	cmdr := commander.New("~/.swat")
+	if !mcpOnly {
+		go cmdr.BackgroundLoop(60 * time.Second)
+		log.Println("SWAT Commander starting...")
+	} else {
+		log.Println("SWAT MCP server starting (no commander loop)...")
+	}
+
 	if err := mcp.Serve(cmdr); err != nil {
 		log.Fatalf("MCP server error: %v", err)
 	}


### PR DESCRIPTION
Allows SWAT to run as a pure MCP tool server without the background commander loop.

**Use case:** Embedding SWAT as an MCP server in Claude Code sessions (e.g. for a review squad Captain to dispatch fix tasks back to swat-dev).

**Usage:**
```json
{
  "mcpServers": {
    "swat": {
      "command": "swat",
      "args": ["--mcp-only"]
    }
  }
}
```

When `--mcp-only` is passed, only the MCP server starts — no commander background loop runs.