### PR TITLE
fix: auto-add ~/.local/bin to PATH in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -233,11 +233,25 @@ register_plugin() {
 }
 
 post_install() {
-    # PATH check
+    # PATH check — auto-add if missing
     if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then
-        info "Add to your shell profile:"
-        echo "  export PATH=\"$BIN_DIR:\$PATH\""
-        echo ""
+        local line="export PATH=\"$BIN_DIR:\$PATH\""
+        local added=false
+        for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
+            if [[ -f "$rc" ]] && ! grep -qF "$BIN_DIR" "$rc" 2>/dev/null; then
+                echo "" >> "$rc"
+                echo "# Added by SWAT installer" >> "$rc"
+                echo "$line" >> "$rc"
+                added=true
+                ok "Added $BIN_DIR to PATH in $(basename "$rc")"
+            fi
+        done
+        if [[ "$added" == false ]]; then
+            info "Add to your shell profile:"
+            echo "  $line"
+            echo ""
+        fi
+        export PATH="$BIN_DIR:$PATH"
     fi
 
     register_plugin

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -86,6 +86,30 @@ else
     fi
 fi
 
+# --- Remove skill --------------------------------------------------------
+
+for dir in "$HOME/.npm-global/lib/node_modules/openclaw/skills" "/usr/local/lib/node_modules/openclaw/skills" "/usr/lib/node_modules/openclaw/skills"; do
+    if [[ -d "$dir/swat" ]]; then
+        rm -rf "$dir/swat"
+        ok "Removed skill from $dir/swat/"
+        break
+    fi
+done
+
+# --- Remove PATH entry from shell profiles -------------------------------
+
+for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
+    if [[ -f "$rc" ]] && grep -q "# Added by SWAT installer" "$rc" 2>/dev/null; then
+        # Remove the comment line and the export line right after it
+        if sed --version &>/dev/null 2>&1; then
+            sed -i '/# Added by SWAT installer/{N;d;}' "$rc"
+        else
+            sed -i '' '/# Added by SWAT installer/{N;d;}' "$rc"
+        fi
+        ok "Cleaned PATH from $(basename "$rc")"
+    fi
+done
+
 # --- Remove OpenClaw plugin config --------------------------------------
 
 OPENCLAW_CONFIG="$HOME/.openclaw/openclaw.json"


### PR DESCRIPTION
The installer now writes `export PATH="$HOME/.local/bin:$PATH"` to `.bashrc`/`.zshrc` automatically, so `swat` is available immediately in new shells.

Previously it only printed a hint that users often missed, causing `swat` to not be found in PATH despite being installed.