### PR TITLE
feat: add --version flag with ldflags injection, remove .version file mechanism

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
-        run: go build -o swat .
+        run: go build -ldflags "-X main.version=${{ github.ref_name }}" -o swat .
 
       - name: Package tarball
         run: |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ curl -fsSL https://raw.githubusercontent.com/LangSensei/swat-v2/master/install.s
 
 This will:
 1. Download the latest release for your platform (Linux/macOS, amd64/arm64)
-2. Install the SWAT binary to `~/.local/bin/`
+2. Install the SWAT binary to `~/.local/bin/` (auto-added to PATH in your shell profile)
 3. Set up the OpenClaw bridge plugin at `~/.swat/plugin/`
 4. Install framework blueprints to `~/.swat/blueprints/`
 5. Auto-register the plugin in your OpenClaw config
@@ -46,6 +46,15 @@ SWAT is controlled entirely through OpenClaw — no CLI needed. Just chat natura
 - `swat_schedule_delete` — Delete a schedule
 
 For detailed tool usage and monitoring patterns, see [`skill/SKILL.md`](skill/SKILL.md).
+
+### CLI Flags
+
+The `swat` binary supports the following flags:
+
+| Flag | Description |
+|------|-------------|
+| `--version` | Print the installed version (`swat <version>`) and exit |
+| `--mcp-only` | Start only the MCP server — skip the background commander loop |
 
 ## 🧠 Architecture
 
@@ -118,6 +127,8 @@ Built-in Go cron scheduler for recurring tasks — zero LLM cost:
 
 ```bash
 go build -o swat .   # Go 1.24+
+# With version injection:
+go build -ldflags "-X main.version=v1.0.0" -o swat .
 ```
 
 ## 📄 License

--- a/install.sh
+++ b/install.sh
@@ -103,8 +103,9 @@ fetch_release() {
     info "Latest release: $tag"
 
     # Check if already installed at this version
-    local version_file="$SWAT_HOME/.version"
-    if [[ -f "$version_file" ]] && [[ "$(cat "$version_file")" == "$tag" ]]; then
+    local current
+    current=$(swat --version 2>/dev/null | awk '{print $2}' || true)
+    if [[ -n "$current" ]] && [[ "$current" == "$tag" ]]; then
         ok "Already up to date ($tag)"
         exit 0
     fi
@@ -283,9 +284,6 @@ main() {
 
     echo ""
     ok "SWAT v2 installed successfully! 🚀"
-
-    # Record installed version
-    echo "$TAG" > "$SWAT_HOME/.version"
 
     echo ""
     info "Next steps:"

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"time"
@@ -9,7 +10,14 @@ import (
 	"github.com/LangSensei/swat/mcp"
 )
 
+var version = "dev"
+
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "--version" {
+		fmt.Printf("swat %s\n", version)
+		os.Exit(0)
+	}
+
 	mcpOnly := len(os.Args) > 1 && os.Args[1] == "--mcp-only"
 
 	cmdr := commander.New("~/.swat")

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -24,7 +24,6 @@ if [[ "${1:-}" != "--yes" ]]; then
     echo "  - Binary:     $BIN_DIR/swat"
     echo "  - Plugin:     $SWAT_HOME/plugin/"
     echo "  - Blueprints: $SWAT_HOME/blueprints/"
-    echo "  - Version:    $SWAT_HOME/.version"
     echo ""
     warn "Runtime data ($SWAT_HOME/squads/, $SWAT_HOME/schedules/) will be KEPT unless you pass --purge"
     echo ""
@@ -62,10 +61,6 @@ if [[ -d "$SWAT_HOME/blueprints" ]]; then
     rm -rf "$SWAT_HOME/blueprints"
     ok "Removed $SWAT_HOME/blueprints/"
 fi
-
-# --- Remove version file ------------------------------------------------
-
-rm -f "$SWAT_HOME/.version"
 
 # --- Purge runtime data -------------------------------------------------
 


### PR DESCRIPTION
## What
Add a `--version` flag to the SWAT binary that prints `swat <version>` and exits. The version is injected at build time via Go ldflags. The old `.version` file mechanism (write on install, read to check for upgrades, delete on uninstall) is removed entirely.

## Why
Using the binary itself as the source of truth for version info is more reliable and idiomatic. The `.version` file was fragile — it could get out of sync if the binary was replaced manually or if the install failed partway through.

## Changes
- `main.go`: add `var version = "dev"` and check `--version` flag before starting commander/MCP (prints `swat <version>` and exits)
- `.github/workflows/release.yml`: inject version via `-ldflags "-X main.version=${{ github.ref_name }}"` at build time
- `install.sh`: replace `.version` file read with `swat --version 2>/dev/null | awk '{print $2}'` for up-to-date check; remove `.version` file write at end of install
- `uninstall.sh`: remove `.version` file deletion step and remove it from the confirmation list
- `README.md`: add CLI flags table documenting `--version` and `--mcp-only`; clarify install auto-PATH behavior; add ldflags build example

## How to Test
```bash
# Build with version injection
go build -ldflags "-X main.version=v1.2.3" -o /tmp/swat .
/tmp/swat --version
# Expected output: swat v1.2.3

# Default dev build
go build -o /tmp/swat .
/tmp/swat --version
# Expected output: swat dev
```