### PR TITLE
feat: integrate debrief into protocol seal phase

### DIFF
--- a/blueprints/squads/_framework/PROTOCOL.md
+++ b/blueprints/squads/_framework/PROTOCOL.md
@@ -1,10 +1,10 @@
 ---
 name: protocol
-version: "1.0.0"
-description: Base squad operation protocol — boot, execution, seal
+version: "1.1.0"
+description: Base squad operation protocol — boot, execution, seal, debrief
 dependencies:
-  skills: [planning-with-files, knowledge-with-files]
-  mcps: []
+  skills: [planning-with-files, knowledge-with-files, debrief]
+  mcps: [swat]
 ---
 
 # {SQUAD_NAME} Squad — Operation Protocol
@@ -75,7 +75,11 @@ S4. **Mark completed** — set `status: completed` in `OPERATION.md`
 S5. **Seal knowledge** — see [Knowledge File](#knowledge-file)
 S6. **Update `INTEL.md`** in the squad folder (two levels up from operation folder) — follow the instructions within the file
 S7. **Final verification** — re-read `plan.md`, `progress.md`, and `findings.md`. Confirm the seal phases (report, knowledge, intel) are logged in plan and progress. Fix any gaps.
-S8. **Terminate** — stop the loop. The squad runs in `-p` mode and auto-terminates; the terminal tab closes when the process exits.
+S8. **Debrief** — choose exactly one exit (see the debrief skill for details):
+   - **Notify** — if this is the final step and no further work is needed, use `notify.sh` from the debrief skill to send a concise notification to the user with your key findings. Lead with the conclusion, include key data points, keep it to 2-5 sentences.
+   - **Dispatch** — if further work is needed by another squad, use the `swat_dispatch` MCP tool to hand off the next task with a clear brief and reference to this operation's findings.
+   Never both. Never neither. Every operation must have exactly one exit.
+S9. **Terminate** — stop the loop. The squad runs in `-p` mode and auto-terminates; the terminal tab closes when the process exits.
 
 ### Reference
 

--- a/blueprints/squads/_framework/PROTOCOL.md
+++ b/blueprints/squads/_framework/PROTOCOL.md
@@ -4,7 +4,7 @@ version: "1.1.0"
 description: Base squad operation protocol — boot, execution, seal, debrief
 dependencies:
   skills: [planning-with-files, knowledge-with-files, debrief]
-  mcps: [swat]
+  mcps: []
 ---
 
 # {SQUAD_NAME} Squad — Operation Protocol

--- a/blueprints/squads/_framework/PROTOCOL.md
+++ b/blueprints/squads/_framework/PROTOCOL.md
@@ -77,10 +77,10 @@ S4. **Mark completed** — set `status: completed` in `OPERATION.md`
 
 Steps in this section use the **D** prefix. Debrief happens immediately after seal — deliver results before anything else.
 
-D1. **Choose exactly one exit** (see the debrief skill for details):
+D1. **Choose exactly one handoff** (see the debrief skill for details):
    - **Notify** — if this is the final step and no further work is needed, use `notify.sh` from the debrief skill to send a concise notification to the user with your key findings. Lead with the conclusion, include key data points, keep it to 2-5 sentences.
    - **Dispatch** — if further work is needed by another squad, use the `swat_dispatch` MCP tool to hand off the next task with a clear brief and reference to this operation's findings.
-   Never both. Never neither. Every operation must have exactly one exit.
+   Never both. Never neither.
 
 #### Learn
 

--- a/blueprints/squads/_framework/PROTOCOL.md
+++ b/blueprints/squads/_framework/PROTOCOL.md
@@ -1,7 +1,7 @@
 ---
 name: protocol
 version: "1.1.0"
-description: Base squad operation protocol — boot, execution, seal, debrief
+description: Base squad operation protocol — boot, execution, seal, debrief, learn
 dependencies:
   skills: [planning-with-files, knowledge-with-files, debrief]
   mcps: []
@@ -72,14 +72,24 @@ S1. **Verify planning files:**
 S2. **Fill `OPERATION.md`** — write `summary` (2-3 sentences), set `completed_at` timestamp, fill any remaining output schema fields — follow the guidance comments in `OPERATION.md`. Leave `status: in-progress` (do NOT set completed yet).
 S3. **Generate `report.html`** in the operation root (see [Report Generation](#report-generation))
 S4. **Mark completed** — set `status: completed` in `OPERATION.md`
-S5. **Seal knowledge** — see [Knowledge File](#knowledge-file)
-S6. **Update `INTEL.md`** in the squad folder (two levels up from operation folder) — follow the instructions within the file
-S7. **Final verification** — re-read `plan.md`, `progress.md`, and `findings.md`. Confirm the seal phases (report, knowledge, intel) are logged in plan and progress. Fix any gaps.
-S8. **Debrief** — choose exactly one exit (see the debrief skill for details):
+
+#### Debrief
+
+Steps in this section use the **D** prefix. Debrief happens immediately after seal — deliver results before anything else.
+
+D1. **Choose exactly one exit** (see the debrief skill for details):
    - **Notify** — if this is the final step and no further work is needed, use `notify.sh` from the debrief skill to send a concise notification to the user with your key findings. Lead with the conclusion, include key data points, keep it to 2-5 sentences.
    - **Dispatch** — if further work is needed by another squad, use the `swat_dispatch` MCP tool to hand off the next task with a clear brief and reference to this operation's findings.
    Never both. Never neither. Every operation must have exactly one exit.
-S9. **Terminate** — stop the loop. The squad runs in `-p` mode and auto-terminates; the terminal tab closes when the process exits.
+
+#### Learn
+
+Steps in this section use the **L** prefix. Learning happens after debrief — the user already has their results.
+
+L1. **Seal knowledge** — see [Knowledge File](#knowledge-file)
+L2. **Update `INTEL.md`** in the squad folder (two levels up from operation folder) — follow the instructions within the file
+L3. **Final verification** — re-read `plan.md`, `progress.md`, and `findings.md`. Confirm all phases (seal, debrief, learn) are logged in plan and progress. Fix any gaps.
+L4. **Terminate** — stop the loop. The squad runs in `-p` mode and auto-terminates; the terminal tab closes when the process exits.
 
 ### Reference
 

--- a/blueprints/squads/_framework/PROTOCOL.md
+++ b/blueprints/squads/_framework/PROTOCOL.md
@@ -1,7 +1,7 @@
 ---
 name: protocol
 version: "1.1.0"
-description: Base squad operation protocol — boot, execution, seal, debrief, learn
+description: Base squad operation protocol — boot, execution, seal, debrief, distill
 dependencies:
   skills: [planning-with-files, knowledge-with-files, debrief]
   mcps: []
@@ -82,13 +82,13 @@ D1. **Choose exactly one handoff** (see the debrief skill for details):
    - **Dispatch** — if further work is needed by another squad, use the `swat_dispatch` MCP tool to hand off the next task with a clear brief and reference to this operation's findings.
    Never both. Never neither.
 
-#### Learn
+#### Distill
 
-Steps in this section use the **L** prefix. Learning happens after debrief — the user already has their results.
+Steps in this section use the **L** prefix. Distillation happens after debrief — the user already has their results.
 
 L1. **Seal knowledge** — see [Knowledge File](#knowledge-file)
 L2. **Update `INTEL.md`** in the squad folder (two levels up from operation folder) — follow the instructions within the file
-L3. **Final verification** — re-read `plan.md`, `progress.md`, and `findings.md`. Confirm all phases (seal, debrief, learn) are logged in plan and progress. Fix any gaps.
+L3. **Final verification** — re-read `plan.md`, `progress.md`, and `findings.md`. Confirm all phases (seal, debrief, distill) are logged in plan and progress. Fix any gaps.
 L4. **Terminate** — stop the loop. The squad runs in `-p` mode and auto-terminates; the terminal tab closes when the process exits.
 
 ### Reference

--- a/commander/dispatch.go
+++ b/commander/dispatch.go
@@ -86,14 +86,14 @@ func (c *Commander) processOperation(op *Operation) {
 	if reloaded.Squad == "" {
 		c.failOperation(op, "classify failed: no squad assigned")
 		squadCount := c.countSquads()
-		c.Notify(fmt.Sprintf("⚠️ Task could not be classified — no matching squad found.\n\nBrief: %s\n\n%d squads installed, none matched. Try `swat squads` to see available squads or `swat browse` to find new ones.", op.Brief, squadCount))
+		c.Notify(fmt.Sprintf("⚠️ Task could not be classified — no matching squad found.\n\nOperation: %s\nBrief: %s\n\n%d squads installed, none matched. Try `swat squads` to see available squads or `swat browse` to find new ones.", op.OperationID, op.Brief, squadCount))
 		return
 	}
 
 	// Validate squad exists in blueprints
 	if !validateSquad(reloaded.Squad) {
 		c.failOperation(op, fmt.Sprintf("classify assigned unknown squad: %s", reloaded.Squad))
-		c.Notify(fmt.Sprintf("⚠️ Task classified to squad '%s' which is not installed.\n\nBrief: %s\n\nTry `swat install %s` or `swat browse` to check availability.", reloaded.Squad, op.Brief, reloaded.Squad))
+		c.Notify(fmt.Sprintf("⚠️ Task classified to squad '%s' which is not installed.\n\nOperation: %s\nBrief: %s\n\nTry `swat install %s` or `swat browse` to check availability.", reloaded.Squad, op.OperationID, op.Brief, reloaded.Squad))
 		return
 	}
 

--- a/commander/dispatch.go
+++ b/commander/dispatch.go
@@ -85,14 +85,16 @@ func (c *Commander) processOperation(op *Operation) {
 
 	if reloaded.Squad == "" {
 		c.failOperation(op, "classify failed: no squad assigned")
-		c.Notify(fmt.Sprintf("⚠️ Task could not be classified — no matching squad found.\n\nBrief: %s", op.Brief))
+		squads := c.listSquadSummaries()
+		c.Notify(fmt.Sprintf("⚠️ Task could not be classified — no matching squad found.\n\nBrief: %s\n\nAvailable squads:\n%s", op.Brief, squads))
 		return
 	}
 
 	// Validate squad exists in blueprints
 	if !validateSquad(reloaded.Squad) {
 		c.failOperation(op, fmt.Sprintf("classify assigned unknown squad: %s", reloaded.Squad))
-		c.Notify(fmt.Sprintf("⚠️ Task classified to squad '%s' which doesn't exist.\n\nBrief: %s", reloaded.Squad, op.Brief))
+		squads := c.listSquadSummaries()
+		c.Notify(fmt.Sprintf("⚠️ Task classified to squad '%s' which is not installed.\n\nBrief: %s\n\nInstalled squads:\n%s", reloaded.Squad, op.Brief, squads))
 		return
 	}
 

--- a/commander/dispatch.go
+++ b/commander/dispatch.go
@@ -85,16 +85,15 @@ func (c *Commander) processOperation(op *Operation) {
 
 	if reloaded.Squad == "" {
 		c.failOperation(op, "classify failed: no squad assigned")
-		squads := c.listSquadSummaries()
-		c.Notify(fmt.Sprintf("⚠️ Task could not be classified — no matching squad found.\n\nBrief: %s\n\nAvailable squads:\n%s", op.Brief, squads))
+		squadCount := c.countSquads()
+		c.Notify(fmt.Sprintf("⚠️ Task could not be classified — no matching squad found.\n\nBrief: %s\n\n%d squads installed, none matched. Try `swat squads` to see available squads or `swat browse` to find new ones.", op.Brief, squadCount))
 		return
 	}
 
 	// Validate squad exists in blueprints
 	if !validateSquad(reloaded.Squad) {
 		c.failOperation(op, fmt.Sprintf("classify assigned unknown squad: %s", reloaded.Squad))
-		squads := c.listSquadSummaries()
-		c.Notify(fmt.Sprintf("⚠️ Task classified to squad '%s' which is not installed.\n\nBrief: %s\n\nInstalled squads:\n%s", reloaded.Squad, op.Brief, squads))
+		c.Notify(fmt.Sprintf("⚠️ Task classified to squad '%s' which is not installed.\n\nBrief: %s\n\nTry `swat install %s` or `swat browse` to check availability.", reloaded.Squad, op.Brief, reloaded.Squad))
 		return
 	}
 

--- a/commander/dispatch.go
+++ b/commander/dispatch.go
@@ -85,12 +85,14 @@ func (c *Commander) processOperation(op *Operation) {
 
 	if reloaded.Squad == "" {
 		c.failOperation(op, "classify failed: no squad assigned")
+		c.Notify(fmt.Sprintf("⚠️ Task could not be classified — no matching squad found.\n\nBrief: %s", op.Brief))
 		return
 	}
 
 	// Validate squad exists in blueprints
 	if !validateSquad(reloaded.Squad) {
 		c.failOperation(op, fmt.Sprintf("classify assigned unknown squad: %s", reloaded.Squad))
+		c.Notify(fmt.Sprintf("⚠️ Task classified to squad '%s' which doesn't exist.\n\nBrief: %s", reloaded.Squad, op.Brief))
 		return
 	}
 

--- a/commander/dispatch.go
+++ b/commander/dispatch.go
@@ -86,14 +86,14 @@ func (c *Commander) processOperation(op *Operation) {
 	if reloaded.Squad == "" {
 		c.failOperation(op, "classify failed: no squad assigned")
 		squads := c.listSquadSummaries()
-		c.NotifySmart(fmt.Sprintf("[SWAT classify failed] Operation %s could not be classified — no matching squad.\n\nBrief: %s\n\nInstalled squads:\n%s\n\nPlease analyze the situation and recommend actions to the user (e.g., create a new squad, rephrase the task, install from marketplace).", op.OperationID, op.Brief, squads))
+		c.Notify(fmt.Sprintf("⚠️ Task could not be classified — no matching squad found.\n\nOperation: %s\nBrief: %s\n\nInstalled squads:\n%s\n\nSuggestions: install a new squad from marketplace (`swat browse`) or rephrase the task.", op.OperationID, op.Brief, squads))
 		return
 	}
 
 	// Validate squad exists in blueprints
 	if !validateSquad(reloaded.Squad) {
 		c.failOperation(op, fmt.Sprintf("classify assigned unknown squad: %s", reloaded.Squad))
-		c.NotifySmart(fmt.Sprintf("[SWAT classify failed] Operation %s was classified to squad '%s' which is not installed.\n\nBrief: %s\n\nPlease check if this squad is available in the marketplace and recommend actions to the user.", op.OperationID, reloaded.Squad, op.Brief))
+		c.Notify(fmt.Sprintf("⚠️ Task classified to squad '%s' which is not installed.\n\nOperation: %s\nBrief: %s\n\nTry `swat install %s` or `swat browse` to check availability.", reloaded.Squad, op.OperationID, op.Brief, reloaded.Squad))
 		return
 	}
 

--- a/commander/dispatch.go
+++ b/commander/dispatch.go
@@ -85,15 +85,15 @@ func (c *Commander) processOperation(op *Operation) {
 
 	if reloaded.Squad == "" {
 		c.failOperation(op, "classify failed: no squad assigned")
-		squadCount := c.countSquads()
-		c.Notify(fmt.Sprintf("⚠️ Task could not be classified — no matching squad found.\n\nOperation: %s\nBrief: %s\n\n%d squads installed, none matched. Try `swat squads` to see available squads or `swat browse` to find new ones.", op.OperationID, op.Brief, squadCount))
+		squads := c.listSquadSummaries()
+		c.NotifySmart(fmt.Sprintf("[SWAT classify failed] Operation %s could not be classified — no matching squad.\n\nBrief: %s\n\nInstalled squads:\n%s\n\nPlease analyze the situation and recommend actions to the user (e.g., create a new squad, rephrase the task, install from marketplace).", op.OperationID, op.Brief, squads))
 		return
 	}
 
 	// Validate squad exists in blueprints
 	if !validateSquad(reloaded.Squad) {
 		c.failOperation(op, fmt.Sprintf("classify assigned unknown squad: %s", reloaded.Squad))
-		c.Notify(fmt.Sprintf("⚠️ Task classified to squad '%s' which is not installed.\n\nOperation: %s\nBrief: %s\n\nTry `swat install %s` or `swat browse` to check availability.", reloaded.Squad, op.OperationID, op.Brief, reloaded.Squad))
+		c.NotifySmart(fmt.Sprintf("[SWAT classify failed] Operation %s was classified to squad '%s' which is not installed.\n\nBrief: %s\n\nPlease check if this squad is available in the marketplace and recommend actions to the user.", op.OperationID, reloaded.Squad, op.Brief))
 		return
 	}
 

--- a/commander/notify.go
+++ b/commander/notify.go
@@ -21,14 +21,20 @@ func (c *Commander) Notify(message string) error {
 		return fmt.Errorf("OPENCLAW_NOTIFY_TARGET not set")
 	}
 
+	args := map[string]interface{}{
+		"action":  "send",
+		"target":  target,
+		"message": message,
+	}
+
+	// Only set channel if explicitly configured; otherwise let Gateway use default
+	if ch := os.Getenv("OPENCLAW_NOTIFY_CHANNEL"); ch != "" {
+		args["channel"] = ch
+	}
+
 	payload := map[string]interface{}{
 		"tool": "message",
-		"args": map[string]interface{}{
-			"action":  "send",
-			"channel": getEnvOr("OPENCLAW_NOTIFY_CHANNEL", "telegram"),
-			"target":  target,
-			"message": message,
-		},
+		"args": args,
 	}
 
 	body, err := json.Marshal(payload)

--- a/commander/notify.go
+++ b/commander/notify.go
@@ -9,34 +9,43 @@ import (
 	"time"
 )
 
-// Notify sends a notification to the user via OpenClaw Gateway /tools/invoke API.
-// Falls back silently if environment variables are not configured.
+// Notify sends a notification directly to the user via OpenClaw Gateway message tool.
+// Use for straightforward notifications (success, progress).
 func (c *Commander) Notify(message string) error {
-	port := os.Getenv("OPENCLAW_GATEWAY_PORT")
-	if port == "" {
-		port = "18789"
-	}
+	return c.gatewayInvoke("message", map[string]interface{}{
+		"action":  "send",
+		"channel": getEnvOr("OPENCLAW_NOTIFY_CHANNEL", "telegram"),
+		"target":  os.Getenv("OPENCLAW_NOTIFY_TARGET"),
+		"message": message,
+	})
+}
+
+// NotifySmart injects a message into the OpenClaw main session via cron wake,
+// allowing the LLM to analyze and respond intelligently.
+// Use for failures and situations that need LLM judgment (e.g., recommending actions).
+func (c *Commander) NotifySmart(message string) error {
+	return c.gatewayInvoke("cron", map[string]interface{}{
+		"action": "wake",
+		"text":   message,
+		"mode":   "now",
+	})
+}
+
+// gatewayInvoke calls OpenClaw Gateway /tools/invoke API
+func (c *Commander) gatewayInvoke(tool string, args map[string]interface{}) error {
+	port := getEnvOr("OPENCLAW_GATEWAY_PORT", "18789")
 	token := os.Getenv("OPENCLAW_GATEWAY_TOKEN")
 	if token == "" {
 		return fmt.Errorf("OPENCLAW_GATEWAY_TOKEN not set")
 	}
-	target := os.Getenv("OPENCLAW_NOTIFY_TARGET")
-	if target == "" {
+
+	if tool == "message" && os.Getenv("OPENCLAW_NOTIFY_TARGET") == "" {
 		return fmt.Errorf("OPENCLAW_NOTIFY_TARGET not set")
-	}
-	channel := os.Getenv("OPENCLAW_NOTIFY_CHANNEL")
-	if channel == "" {
-		channel = "telegram"
 	}
 
 	payload := map[string]interface{}{
-		"tool": "message",
-		"args": map[string]interface{}{
-			"action":  "send",
-			"channel": channel,
-			"target":  target,
-			"message": message,
-		},
+		"tool": tool,
+		"args": args,
 	}
 
 	body, err := json.Marshal(payload)
@@ -64,4 +73,11 @@ func (c *Commander) Notify(message string) error {
 	}
 
 	return nil
+}
+
+func getEnvOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
 }

--- a/commander/notify.go
+++ b/commander/notify.go
@@ -1,0 +1,67 @@
+package commander
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+// Notify sends a notification to the user via OpenClaw Gateway /tools/invoke API.
+// Falls back silently if environment variables are not configured.
+func (c *Commander) Notify(message string) error {
+	port := os.Getenv("OPENCLAW_GATEWAY_PORT")
+	if port == "" {
+		port = "18789"
+	}
+	token := os.Getenv("OPENCLAW_GATEWAY_TOKEN")
+	if token == "" {
+		return fmt.Errorf("OPENCLAW_GATEWAY_TOKEN not set")
+	}
+	target := os.Getenv("OPENCLAW_NOTIFY_TARGET")
+	if target == "" {
+		return fmt.Errorf("OPENCLAW_NOTIFY_TARGET not set")
+	}
+	channel := os.Getenv("OPENCLAW_NOTIFY_CHANNEL")
+	if channel == "" {
+		channel = "telegram"
+	}
+
+	payload := map[string]interface{}{
+		"tool": "message",
+		"args": map[string]interface{}{
+			"action":  "send",
+			"channel": channel,
+			"target":  target,
+			"message": message,
+		},
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+
+	url := fmt.Sprintf("http://127.0.0.1:%s/tools/invoke", port)
+	req, err := http.NewRequest("POST", url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("gateway returned %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/commander/notify.go
+++ b/commander/notify.go
@@ -9,43 +9,26 @@ import (
 	"time"
 )
 
-// Notify sends a notification directly to the user via OpenClaw Gateway message tool.
-// Use for straightforward notifications (success, progress).
+// Notify sends a notification to the user via OpenClaw Gateway message tool.
 func (c *Commander) Notify(message string) error {
-	return c.gatewayInvoke("message", map[string]interface{}{
-		"action":  "send",
-		"channel": getEnvOr("OPENCLAW_NOTIFY_CHANNEL", "telegram"),
-		"target":  os.Getenv("OPENCLAW_NOTIFY_TARGET"),
-		"message": message,
-	})
-}
-
-// NotifySmart injects a message into the OpenClaw main session via cron wake,
-// allowing the LLM to analyze and respond intelligently.
-// Use for failures and situations that need LLM judgment (e.g., recommending actions).
-func (c *Commander) NotifySmart(message string) error {
-	return c.gatewayInvoke("cron", map[string]interface{}{
-		"action": "wake",
-		"text":   message,
-		"mode":   "now",
-	})
-}
-
-// gatewayInvoke calls OpenClaw Gateway /tools/invoke API
-func (c *Commander) gatewayInvoke(tool string, args map[string]interface{}) error {
 	port := getEnvOr("OPENCLAW_GATEWAY_PORT", "18789")
 	token := os.Getenv("OPENCLAW_GATEWAY_TOKEN")
 	if token == "" {
 		return fmt.Errorf("OPENCLAW_GATEWAY_TOKEN not set")
 	}
-
-	if tool == "message" && os.Getenv("OPENCLAW_NOTIFY_TARGET") == "" {
+	target := os.Getenv("OPENCLAW_NOTIFY_TARGET")
+	if target == "" {
 		return fmt.Errorf("OPENCLAW_NOTIFY_TARGET not set")
 	}
 
 	payload := map[string]interface{}{
-		"tool": tool,
-		"args": args,
+		"tool": "message",
+		"args": map[string]interface{}{
+			"action":  "send",
+			"channel": getEnvOr("OPENCLAW_NOTIFY_CHANNEL", "telegram"),
+			"target":  target,
+			"message": message,
+		},
 	}
 
 	body, err := json.Marshal(payload)

--- a/commander/squads.go
+++ b/commander/squads.go
@@ -46,6 +46,15 @@ func (c *Commander) ListSquads() ([]map[string]string, error) {
 	return squads, nil
 }
 
+// countSquads returns the number of installed squads
+func (c *Commander) countSquads() int {
+	squads, err := c.ListSquads()
+	if err != nil {
+		return 0
+	}
+	return len(squads)
+}
+
 // listSquadSummaries returns a formatted string of installed squads and their descriptions
 func (c *Commander) listSquadSummaries() string {
 	squads, err := c.ListSquads()

--- a/commander/squads.go
+++ b/commander/squads.go
@@ -46,6 +46,23 @@ func (c *Commander) ListSquads() ([]map[string]string, error) {
 	return squads, nil
 }
 
+// listSquadSummaries returns a formatted string of installed squads and their descriptions
+func (c *Commander) listSquadSummaries() string {
+	squads, err := c.ListSquads()
+	if err != nil || len(squads) == 0 {
+		return "(none installed)"
+	}
+	var lines []string
+	for _, sq := range squads {
+		desc := sq["description"]
+		if desc == "" {
+			desc = "(no description)"
+		}
+		lines = append(lines, fmt.Sprintf("• %s — %s", sq["name"], desc))
+	}
+	return strings.Join(lines, "\n")
+}
+
 // Browse lists all squads available in the marketplace
 func (c *Commander) Browse() ([]BrowseResult, error) {
 	entries, err := ghListDir("squads")

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -66,14 +66,7 @@ Use `swat_schedules` to view all schedules and `swat_schedule_delete(id)` to rem
 
 ## Completion Notifications
 
-Squads **automatically notify the user** when they finish or fail. Classify failures also trigger automatic notifications.
-
-**You do NOT need to:**
-- Set up completion monitoring cron jobs
-- Poll `swat_ops` in a loop
-- Use active-diff patterns
-
-**You CAN still use `swat_ops`** to check status on-demand when the user asks.
+Squads automatically notify the user when they finish or fail. Use `swat_ops` to check status on-demand when the user asks.
 
 ## Checking Results
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -64,16 +64,9 @@ Use `swat_schedules` to view all schedules and `swat_schedule_delete(id)` to rem
 - SWAT scheduler → deterministic recurring tasks (zero LLM cost, e.g. "analyze X every Monday")
 - OpenClaw cron → tasks needing LLM judgment
 
-## Completion Notifications (Debrief)
+## Completion Notifications
 
-Squads **automatically notify the user** when they finish. No polling or monitoring needed.
-
-Each squad follows the protocol: **Seal → Debrief → Distill**
-- **Seal**: verify work, write summary, generate report, mark completed
-- **Debrief**: notify user (via OpenClaw Gateway) OR dispatch next squad
-- **Distill**: knowledge + INTEL sedimentation (happens after user is notified)
-
-**Classify failures** (no matching squad, unknown squad) also trigger automatic notifications to the user with actionable suggestions.
+Squads **automatically notify the user** when they finish or fail. Classify failures also trigger automatic notifications.
 
 **You do NOT need to:**
 - Set up completion monitoring cron jobs

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swat
-description: "SWAT autonomous squad orchestration. Use when: dispatching tasks, checking operation status, managing squads/schedules, or monitoring task completions. Covers dispatch workflow, completion monitoring (active-diff cron pattern), scheduling, and marketplace operations."
+description: "SWAT autonomous squad orchestration. Use when: dispatching tasks, checking operation status, managing squads/schedules, or monitoring task completions. Covers dispatch workflow, debrief notifications, scheduling, and marketplace operations."
 ---
 
 # SWAT - Autonomous Squad Orchestration
@@ -62,53 +62,51 @@ Use `swat_schedules` to view all schedules and `swat_schedule_delete(id)` to rem
 
 **When to use SWAT scheduler vs OpenClaw cron:**
 - SWAT scheduler → deterministic recurring tasks (zero LLM cost, e.g. "analyze X every Monday")
-- OpenClaw cron → tasks needing LLM judgment (e.g. completion monitoring with active-diff)
+- OpenClaw cron → tasks needing LLM judgment
+
+## Completion Notifications (Debrief)
+
+Squads **automatically notify the user** when they finish. No polling or monitoring needed.
+
+Each squad follows the protocol: **Seal → Debrief → Distill**
+- **Seal**: verify work, write summary, generate report, mark completed
+- **Debrief**: notify user (via OpenClaw Gateway) OR dispatch next squad
+- **Distill**: knowledge + INTEL sedimentation (happens after user is notified)
+
+**Classify failures** (no matching squad, unknown squad) also trigger automatic notifications to the user with actionable suggestions.
+
+**You do NOT need to:**
+- Set up completion monitoring cron jobs
+- Poll `swat_ops` in a loop
+- Use active-diff patterns
+
+**You CAN still use `swat_ops`** to check status on-demand when the user asks.
 
 ## Checking Results
 
 - Call `swat_ops` **only when the user asks** about a task, or when you have a natural reason to check (e.g., heartbeat).
-- **Never** use `sleep`, polling loops, or repeated `exec` calls to wait for completion. This blocks the main session and makes you unresponsive.
+- **Never** use `sleep`, polling loops, or repeated `exec` calls to wait for completion.
 - `swat_ops` returns counts + operations. Filters:
   - `status` — `queued`, `active`, `completed`, `failed`
-  - `since` — RFC3339 timestamp (e.g. `2026-03-09T04:00:00Z`), only returns terminal ops after this time; active/queued always included
+  - `since` — RFC3339 timestamp, only returns terminal ops after this time; active/queued always included
   - `limit` — max results (default 50)
   - `offset` — skip first N results (default 0)
   - Results sorted by time descending (most recent first)
 
-## Completion Monitoring
-
-SWAT tasks run in the background — both manual dispatches and scheduled tasks. To get notified when tasks complete, set up a **persistent** OpenClaw cron job:
-
-```
-cron(action=add, job={
-  name: "swat-monitor",
-  schedule: { kind: "every", everyMs: 300000 },
-  sessionTarget: "isolated",
-  payload: {
-    kind: "agentTurn",
-    message: "You are a SWAT completion monitor.\n\n1. Read workspace file memory/swat-monitor.json. If missing, treat lastKnownIds as [].\n2. Call swat_ops(status=completed, limit=10) and swat_ops(status=failed, limit=10) to get recent terminal operations.\n3. Find new completions/failures: IDs present in results but NOT in lastKnownIds.\n4. For each new result, send the user a summary (operation ID, squad, brief, status, key findings).\n5. Update memory/swat-monitor.json with all reported IDs (keep last 50 to avoid unbounded growth).\n6. If nothing new, reply NO_REPLY."
-  },
-  delivery: { mode: "announce" }
-})
-```
-
-- **Persistent**: This cron runs continuously (every 5 min), not just after dispatch. It catches both manual and scheduled task completions.
-- **Set up once**: Create this cron after SWAT is installed. Check `cron(action=list)` before creating — don't stack duplicates.
-- **Interval**: 5 minutes is the default. Use 2 minutes if the user wants faster updates.
-
 ## Critical Rules
 
 1. **Fire and forget** — After dispatch, immediately return control to the user. Do not monitor, poll, or block.
-2. **No sleep/exec polling** — Never run `sleep X && check` or similar patterns. SWAT tasks can take minutes; blocking the session makes you unreachable.
-3. **Auto-classification** — You do NOT need to pick a squad. `swat_dispatch` auto-classifies the task. If no squad fits, the operation fails with a clear reason.
+2. **No sleep/exec polling** — Never run `sleep X && check` or similar patterns.
+3. **Auto-classification** — You do NOT need to pick a squad. `swat_dispatch` auto-classifies the task.
 4. **Concurrent operations** — Multiple tasks can run in parallel across different squads.
-5. **Failed operations** — Include the failure reason when reporting to the user. Unclassified failures stay in `_unclassified/`.
+5. **Failed operations** — Include the failure reason when reporting to the user.
 
 ## Marketplace
 
-- `swat_squad_browse` — See what's available to install (fetches from GitHub, no clone needed).
+- `swat_squad_browse` — See what's available to install.
 - `swat_squad_install(squad)` — Downloads squad + resolves dependencies automatically.
 - `swat_squad_uninstall(squad)` — Removes squad blueprint + cleans up orphaned dependencies.
+- `swat_squad_update(squad)` — Update to latest marketplace version.
 
 ## First Run
 


### PR DESCRIPTION
## What

Integrates the **debrief** completion gate into the protocol's seal sequence.

## Changes

- **Protocol v1.0.0 → v1.1.0**
- Added `debrief` skill + `swat` MCP to protocol dependencies
- New **S8 (Debrief)** step between final verification and terminate

## How it works

Every operation must end with exactly one exit:

| Exit | When | How |
|------|------|-----|
| **Notify** | Final step, no further work | `bash debrief/notify.sh "conclusion"` → OpenClaw Gateway → user |
| **Dispatch** | Further work needed | `swat_dispatch` MCP → Commander → next squad |

Never both. Never neither.

## Seal sequence (before → after)

```
Before:                    After:
S1-S7 (unchanged)          S1-S7 (unchanged)
S8 Terminate               S8 Debrief (notify OR dispatch)
                           S9 Terminate
```

## Why

- Squad has domain knowledge + context to write good notifications
- Commander no longer needs a collect→notify phase
- Push (debrief) complements pull (swat_ops)