### PR TITLE
fix: ensure binaryPath exists before skipping plugin registration

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -197,8 +197,8 @@ register_plugin() {
         return
     fi
 
-    # Check if already registered
-    if grep -q "$plugin_path" "$oc_config" 2>/dev/null; then
+    # Check if already registered AND binaryPath is configured
+    if grep -q "$plugin_path" "$oc_config" 2>/dev/null && grep -q "binaryPath" "$oc_config" 2>/dev/null; then
         ok "Plugin already registered in OpenClaw config"
         return
     fi

--- a/install.sh
+++ b/install.sh
@@ -197,8 +197,8 @@ register_plugin() {
         return
     fi
 
-    # Check if already registered AND binaryPath is configured
-    if grep -q "$plugin_path" "$oc_config" 2>/dev/null && grep -q "binaryPath" "$oc_config" 2>/dev/null; then
+    # Check if already registered AND binaryPath is configured for this plugin
+    if grep -q "$plugin_path" "$oc_config" 2>/dev/null && grep -A5 "swat-mcp-bridge" "$oc_config" 2>/dev/null | grep -q "binaryPath"; then
         ok "Plugin already registered in OpenClaw config"
         return
     fi


### PR DESCRIPTION
## Problem

The idempotency check in `register_plugin()` only verified that the plugin path existed in the OpenClaw config. If `binaryPath` was missing (e.g. from a prior install version or manual config edit), re-running `install.sh` would skip registration, leaving the SWAT plugin broken with:

```
SWAT binary path not configured. Run install.sh or set plugins.entries.swat-mcp-bridge.config.binaryPath
```

## Fix

Now both conditions must be true to skip re-registration:
1. Plugin path present in config
2. `binaryPath` configured

If either is missing, the node script runs and ensures a complete config.