### PR TITLE
fix: report.html guidelines — results over process

### DIFF
--- a/blueprints/squads/_framework/PROTOCOL.md
+++ b/blueprints/squads/_framework/PROTOCOL.md
@@ -126,13 +126,27 @@ Execution:
 
 #### Report Generation
 
-Generate `report.html` in the operation root. Pull content from `OPERATION.md` and all `operators/*/` directories (plan.md, findings.md, progress.md, knowledge.md where present).
+Generate `report.html` in the operation root. This is the **user-facing deliverable** — focus on results, not process.
 
-Requirements:
+**Structure** (use these sections in order):
+
+1. **Executive Summary** — 2-3 sentence conclusion with the answer/recommendation
+2. **Key Findings** — the important discoveries, data points, or insights (use tables, lists, or cards — not prose walls)
+3. **Data & Evidence** — supporting tables, comparisons, charts, or structured data. This is the meat of the report.
+4. **Methodology** — 1-2 short paragraphs summarizing how the work was done. Do NOT copy-paste raw logs, planning files, or progress notes.
+
+**Requirements:**
 - **Single self-contained HTML file** — all CSS inlined, no external dependencies
-- **Responsive** — must be readable on both mobile and desktop (include `<meta name="viewport">`)
-- **Comprehensive** — include all details, not just a summary
-- **Polished** — this is the deliverable, not a raw dump of markdown files. Structure the content for a reader who has no context
+- **Responsive** — readable on mobile and desktop (`<meta name="viewport">`)
+- **Result-oriented** — the reader wants answers, not a replay of your thought process
+- **Visually structured** — prefer tables, cards, and clear headings over long paragraphs
+- **Concise process section** — methodology should be a brief summary, not a dump of plan.md/progress.md/findings.md
+
+**Anti-patterns (do NOT do these):**
+- Copy-pasting raw markdown files into HTML
+- Including full planning logs or step-by-step execution traces
+- Walls of unstructured text
+- Repeating the same information in multiple sections
 
 #### Knowledge File
 


### PR DESCRIPTION
## Problem

Current report guidelines say "comprehensive — include all details" and "pull content from all operators/*/directories". This leads to captains copy-pasting raw plan.md, progress.md, findings.md into HTML — lazy and unreadable.

## Fix

Replace with structured 4-section template:
1. **Executive Summary** — 2-3 sentence conclusion
2. **Key Findings** — tables, lists, cards
3. **Data & Evidence** — supporting structured data
4. **Methodology** — 1-2 paragraph summary (not raw logs)

Added explicit anti-patterns to prevent common mistakes.