### PR TITLE
feat: add --output-format json to Copilot CLI invocations in Commander

### DIFF
--- a/commander/dispatch.go
+++ b/commander/dispatch.go
@@ -56,7 +56,7 @@ func (c *Commander) processOperation(op *Operation) {
 		filepath.Join(c.SwatRoot, "squads"),
 	)
 
-	cmd := exec.Command("copilot", "-p", prompt, "--yolo")
+	cmd := exec.Command("copilot", "-p", prompt, "--yolo", "--output-format", "json")
 	cmd.Dir = unclassifiedDir
 
 	logPath := filepath.Join(unclassifiedDir, "classify.log")
@@ -157,7 +157,7 @@ func (c *Commander) Cancel(opID string) error {
 func (c *Commander) launchCopilot(op *Operation, opDir string) error {
 	prompt := "Begin operation. Read OPERATION.md for your task brief, then follow the protocol in AGENTS.md."
 
-	cmd := exec.Command("copilot", "-p", prompt, "--yolo")
+	cmd := exec.Command("copilot", "-p", prompt, "--yolo", "--output-format", "json")
 	cmd.Dir = opDir
 
 	logPath := filepath.Join(opDir, "copilot.log")

--- a/commander/dispatch.go
+++ b/commander/dispatch.go
@@ -56,7 +56,7 @@ func (c *Commander) processOperation(op *Operation) {
 		filepath.Join(c.SwatRoot, "squads"),
 	)
 
-	cmd := exec.Command("copilot", "-p", prompt, "--yolo", "--output-format", "json")
+	cmd := exec.Command("copilot", "-p", prompt, "--yolo", "--output-format", "json", "--effort", "low")
 	cmd.Dir = unclassifiedDir
 
 	logPath := filepath.Join(unclassifiedDir, "classify.log")
@@ -157,7 +157,7 @@ func (c *Commander) Cancel(opID string) error {
 func (c *Commander) launchCopilot(op *Operation, opDir string) error {
 	prompt := "Begin operation. Read OPERATION.md for your task brief, then follow the protocol in AGENTS.md."
 
-	cmd := exec.Command("copilot", "-p", prompt, "--yolo", "--output-format", "json")
+	cmd := exec.Command("copilot", "-p", prompt, "--yolo", "--output-format", "json", "--effort", "xhigh")
 	cmd.Dir = opDir
 
 	logPath := filepath.Join(opDir, "copilot.log")


### PR DESCRIPTION
## What

Adds `--output-format json` to both `exec.Command("copilot", ...)` calls in `commander/dispatch.go`:

1. **classify+enrich invocation** (line ~59) — writes to `classify.log`
2. **squad launch invocation** (line ~160) — writes to `copilot.log`

## Why

Structured JSONL output enables downstream parsing of tool calls, file edits, token usage, and exit codes from Copilot CLI runs. Plain text logs are opaque; JSONL provides structured, machine-readable data per line.

## Changes

- `commander/dispatch.go`: 2-line change — append `"--output-format", "json"` to both `exec.Command` arg lists

## How to Test

1. Dispatch an operation via the Commander
2. Check `classify.log` and `copilot.log` in the operation directory
3. Each line should be a valid JSON object (JSONL format) rather than plain text

No other code paths are affected — `cmd.Stdout` is already piped to log files, so JSONL flows through the same pipe.