### PR TITLE
fix: classify effort low→xhigh to prevent misclassification

### DIFF
--- a/commander/dispatch.go
+++ b/commander/dispatch.go
@@ -56,7 +56,7 @@ func (c *Commander) processOperation(op *Operation) {
 		filepath.Join(c.SwatRoot, "squads"),
 	)
 
-	cmd := exec.Command("copilot", "-p", prompt, "--yolo", "--output-format", "json", "--effort", "low")
+	cmd := exec.Command("copilot", "-p", prompt, "--yolo", "--output-format", "json", "--effort", "xhigh")
 	cmd.Dir = unclassifiedDir
 
 	logPath := filepath.Join(unclassifiedDir, "classify.log")


### PR DESCRIPTION
Classify with `--effort low` caused Copilot to invent non-existent squad names (e.g. `research` instead of `swat-strategist`). Bumping to `xhigh` ensures reliable squad matching.

Context: operation `20260324-6638d643` failed because classify assigned `research` — a squad that doesn't exist.