### PR TITLE
refactor: restructure OPERATION.md template for clearer role separation

### DIFF
--- a/blueprints/OPERATION.md
+++ b/blueprints/OPERATION.md
@@ -1,48 +1,38 @@
 ---
-# Commander fields (written at dispatch, do not modify)
-# format: YYYYMMDD-8hex (e.g., 20260212-a1b2c3d4)
+# ── COMMANDER (written at dispatch, do not modify) ──
+# format: YYYYMMDD-8hex
 operation_id: {OPERATION_ID}
-# filled by classify (Copilot)
-squad: {SQUAD}
-# who initiated this operation (user | schedule | system)
 source: {SOURCE}
-# written by Commander after launch
 pid: {PID}
-# UTC timestamp when operation was created
 created_at: {CREATED_AT}
-# UTC timestamp when Copilot CLI was launched
 dispatched_at: {DISPATCHED_AT}
-# UTC timestamp when operation failed
 failed_at: {FAILED_AT}
-# filled if status is failed
 failure_reason: {FAILURE_REASON}
-# filled by classify (Copilot)
-# e.g., [{type: "operation", value: "../20260309-xxxx/"}, {type: "url", value: "https://..."}, {type: "email-address", value: "user@example.com"}]
+
+# ── CLASSIFY (written by LLM at classify, do not modify) ──
+squad: {SQUAD}
+# e.g., [{type: "operation", value: "../20260309-xxxx/"}]
 references: {REFERENCES}
 
-# Captain output fields (filled during/after execution)
+# ── CAPTAIN (fill during execution) ──
 # queued → active → completed / failed
 status: {STATUS}
 # 2-3 sentence summary of outcome
 summary: {SUMMARY}
-# UTC timestamp when operation completed successfully
 completed_at: {COMPLETED_AT}
-# Squad-specific output fields
 # {OUTPUT_SCHEMA}
 ---
 
 # {BRIEF}
-<!-- Commander: extracted from brief — do not modify -->
 
 ## Assignment
-<!-- Commander: full operation description — do not modify -->
 {DETAILS}
 
-## Summary
-<!-- Captain: write a rich summary of findings and outcome -->
+### Context
+[CLASSIFY: Historical context, related operations, key metrics from past runs]
 
 ## Findings
-<!-- Captain: key discoveries, root cause, impact, affected environments -->
+[CAPTAIN REQUIRED: Key discoveries, root cause, data points, impact assessment]
 
 ## Action Items
-<!-- Captain: concrete recommendations and next steps -->
+[CAPTAIN REQUIRED: Concrete recommendations, next steps, ownership]

--- a/blueprints/squads/_framework/PROTOCOL.md
+++ b/blueprints/squads/_framework/PROTOCOL.md
@@ -69,7 +69,13 @@ S1. **Verify planning files:**
    a. `plan.md` — all phases marked `complete`, all items resolved (checked off or `[skipped] reason`). If any item is still actionable, go back and execute it.
    b. `progress.md` — every phase has actions logged with actual actions taken, files created/modified, and results observed. If any section is empty or placeholder, fill it in.
    c. `findings.md` — all discoveries captured. If any findings from your investigation are missing, add them now.
-S2. **Fill `OPERATION.md`** — write `summary` (2-3 sentences), set `completed_at` timestamp, fill any remaining output schema fields — follow the guidance comments in `OPERATION.md`. Leave `status: in-progress` (do NOT set completed yet).
+S2. **Fill `OPERATION.md`** — complete ALL of the following:
+   a. Set `summary:` in frontmatter (2-3 sentences)
+   b. Set `completed_at:` timestamp
+   c. Fill any squad-specific output schema fields in frontmatter
+   d. Write `## Findings` section — key discoveries, root cause, data points
+   e. Write `## Action Items` section — concrete recommendations and next steps
+   Leave `status: in-progress` (do NOT set completed yet).
 S3. **Generate `report.html`** in the operation root (see [Report Generation](#report-generation))
 S4. **Mark completed** — set `status: completed` in `OPERATION.md`
 

--- a/commander/dispatch.go
+++ b/commander/dispatch.go
@@ -64,7 +64,7 @@ func (c *Commander) processOperation(op *Operation) {
 			"Your job:\n"+
 			"1. Choose the best squad and update the 'squad' field in OPERATION.md frontmatter.\n"+
 			"2. If you find relevant historical operations, add them to the 'references' field as [{type: \"operation\", value: \"path\"}].\n"+
-			"3. Enrich the ## Assignment section with additional context from historical operations (past findings, key metrics, known issues). Keep the original task description intact, append enrichment below it.\n"+
+			"3. Write enrichment to the `### Context` section (under ## Assignment). Keep the ## Assignment text intact. Write historical context, related operation findings, and key metrics into ### Context, replacing the `[CLASSIFY: ...]` placeholder.\n"+
 			"If no squad is a good fit for the task, leave the squad field empty.\n"+
 			"Do NOT modify any other frontmatter fields besides 'squad' and 'references'.",
 		filepath.Join(c.SwatRoot, "blueprints", "squads"),


### PR DESCRIPTION
## What
Restructure the OPERATION.md template and update PROTOCOL.md to improve Captain LLM compliance with markdown body sections.

## Why
Analysis of 63 completed operations found 29% have empty markdown sections (Findings/Action Items) while all have YAML `summary:` filled. Root causes:
1. HTML comments are low-salience cues for LLMs
2. `## Summary` is redundant with YAML `summary:` field
3. No clear role separation in YAML frontmatter comments
4. Classify enrichment mixed into `## Assignment` text

## Changes
- **blueprints/OPERATION.md**: Split YAML into COMMANDER/CLASSIFY/CAPTAIN sections, remove `## Summary`, add `### Context` for classify enrichment, replace `<!-- -->` with visible `[CAPTAIN REQUIRED:]` and `[CLASSIFY:]` placeholders
- **blueprints/squads/_framework/PROTOCOL.md**: Update Seal S2 to explicitly enumerate required sections (a-e) instead of indirect "follow the guidance comments"
- **commander/dispatch.go**: Update classify prompt to write enrichment to `### Context` section instead of appending to `## Assignment`

## How to Test
1. `go build ./...` — compiles clean
2. Dispatch a new operation and verify OPERATION.md uses the new template structure
3. Verify classify enrichment lands in `### Context` (not mixed into Assignment)
4. Verify Captain fills `## Findings` and `## Action Items` sections (monitor compliance rate)