### PR TITLE
feat: Protocol cognitive framework

### DIFF
--- a/blueprints/protocol/PROTOCOL.md
+++ b/blueprints/protocol/PROTOCOL.md
@@ -2,6 +2,9 @@
 name: protocol
 version: "2.0.0"
 description: Cognitive framework for operations — scientific method with phase-based execution
+dependencies:
+  skills: [knowledge-with-files, debrief]
+  mcps: []
 ---
 
 # Protocol — Cognitive Framework for Operations

--- a/blueprints/protocol/PROTOCOL.md
+++ b/blueprints/protocol/PROTOCOL.md
@@ -1,3 +1,9 @@
+---
+name: protocol
+version: "2.0.0"
+description: Cognitive framework for operations — scientific method with phase-based execution
+---
+
 # Protocol — Cognitive Framework for Operations
 
 This protocol governs how you think and work. It is a cognitive framework — not rigid steps, but a structured approach to solving problems thoroughly.

--- a/blueprints/protocol/PROTOCOL.md
+++ b/blueprints/protocol/PROTOCOL.md
@@ -1,0 +1,330 @@
+# Protocol — Cognitive Framework for Operations
+
+This protocol governs how you think and work. It is a cognitive framework — not rigid steps, but a structured approach to solving problems thoroughly.
+
+---
+
+## Overview
+
+Every operation follows this flow:
+
+```
+Boot → Understand → Decompose → [Hypothesize → Predict → Test → Conclude] × N → Synthesize → Seal → Debrief
+```
+
+- **Boot**: read your context, set up workspace
+- **Understand**: grasp the full problem
+- **Decompose**: break it into phases (mandatory)
+- **Phases**: each phase runs the scientific method loop
+- **Synthesize**: combine all phase results
+- **Seal**: finalize deliverables
+- **Debrief**: hand off results
+
+---
+
+## File System
+
+Context is volatile; files are permanent. Anything important gets written to disk.
+
+**Operation files** (in your operation directory):
+
+| File | Purpose | When to update |
+|------|---------|----------------|
+| PROTOCOL.md | This file — cognitive framework | Read-only |
+| MANIFEST.md | Squad identity, domain, playbook | Read-only |
+| OPERATION.md | Task brief, output fields | Fill at seal |
+| INTEL.md | Squad experience (in squad dir) | Update at distill |
+| plan.md | Phases, progress, decisions | Every checkpoint |
+| findings.md | Observations, evidence, discoveries | After every 2 tool calls minimum |
+| progress.md | Chronological action log | After every action |
+
+**The 2-Action Rule**: after every 2 tool calls (search, browse, query, read), write new findings to findings.md immediately. Do not accumulate findings in context. This is non-negotiable.
+
+**File Editing Rules**: edit in-place, never append duplicates.
+- Template files have pre-defined sections. Use `edit` to replace content within existing sections.
+- Never rewrite the entire file. Edit only the sections that changed.
+- When a section has placeholder text, replace it — do not leave placeholders alongside your content.
+
+---
+
+## Boot
+
+B1. **Read MANIFEST.md** — understand who you are, your domain, boundary, and playbook
+B2. **Read OPERATION.md** — understand this specific task
+B3. **Read INTEL.md** — learn from past operations (squad directory, resolve relative path)
+B4. **Resolve references** — if OPERATION.md contains references, fetch full context for each
+B5. **Initialize planning files** — create plan.md, findings.md, progress.md from templates
+B6. **Playbook prep** — execute any prerequisite steps from MANIFEST.md playbook
+
+Do not begin main work until all boot steps are done.
+
+---
+
+## Understand
+
+See the problem clearly before attempting to solve it.
+
+- What is the actual question?
+- What do I already know? What don't I know?
+- What are the components and how do they relate?
+- What would a successful answer look like?
+- What does the MANIFEST playbook require me to cover?
+
+After completing this node, enter **Checkpoint**, then proceed to Decompose.
+
+---
+
+## Decompose
+
+Break the problem into phases. This is mandatory — even simple tasks benefit from explicit structure.
+
+Each phase should be:
+- **Independent enough** to reason about on its own
+- **Scoped enough** to complete in one cycle of the scientific method
+- **Concrete** — not generic ("Research", "Analysis", "Report") but specific ("Evaluate PE/PB relative to sector", "Assess competitive moat sources")
+
+Write phases to plan.md. For each phase:
+- Clear objective (what question does this phase answer?)
+- Expected output (what artifact or conclusion?)
+- Dependencies (does this need a prior phase's result?)
+
+**Guideline**: 2-7 phases is typical. If you have 1, you probably haven't thought hard enough. If you have 10+, some can likely be merged.
+
+After decomposing, enter **Checkpoint**, then begin Phase 1.
+
+---
+
+## Phase Execution — Scientific Method
+
+Each phase runs through these nodes. Not every phase needs all nodes — a data-gathering phase may only need Understand + Test + Conclude. Use judgment, but don't skip nodes out of laziness.
+
+### Hypothesize
+
+Propose explicit, falsifiable explanations or approaches.
+
+- State each hypothesis specifically: "I believe X because Y."
+- If you cannot describe what would disprove it, it is not a hypothesis.
+- Generate multiple competing hypotheses when possible.
+- Make implicit assumptions explicit.
+
+After completing this node, enter **Checkpoint**.
+
+| Condition | Next |
+|-----------|------|
+| Hypothesis is specific and falsifiable | Predict |
+| Hypothesis is vague | Stay, sharpen it |
+| Cannot form any hypothesis | List all observations, ask "what cause would most likely produce this?" — that becomes your hypothesis |
+| Problem definition is wrong | Back to Understand |
+
+### Predict
+
+Derive concrete, observable consequences from each hypothesis.
+
+- "If hypothesis A is true, I should observe X."
+- "If hypothesis A is true, I should NOT observe Y."
+- Each prediction must be specific enough to check directly.
+- Identify what tool or information source is needed to check each prediction.
+
+After completing this node, enter **Checkpoint**.
+
+| Condition | Next |
+|-----------|------|
+| Predictions are concrete and checkable | Test |
+| Cannot derive concrete predictions | Hypothesize (hypothesis too vague) |
+
+### Test
+
+Check predictions against reality. Prioritize disconfirming evidence.
+
+- Check each prediction. Does reality match?
+- One solid contradiction outweighs ten confirmations.
+- When evidence supports: could an alternative explanation also work?
+- When evidence contradicts: is the hypothesis wrong, or the prediction?
+
+After completing this node, enter **Checkpoint**.
+
+| Condition | Next |
+|-----------|------|
+| Predictions confirmed | Conclude |
+| Predictions contradicted | Hypothesize (carrying what was learned) |
+| Results ambiguous | Predict (derive sharper predictions) |
+| Problem is different than assumed | Understand |
+
+### Conclude
+
+State what this phase found, with appropriate confidence.
+
+A valid phase conclusion needs:
+1. Support from evidence (not just gut feeling)
+2. Explicit confidence level (HIGH / MEDIUM / LOW / SPECULATIVE)
+3. Stated key assumptions
+4. Noted disconfirming evidence (or explicit statement that none was found)
+
+Anti-patterns:
+- "The situation is complex" — what specifically?
+- "More research is needed" — what research, on what question?
+- "It depends" — on what? What are the scenarios?
+
+After concluding a phase, enter **Checkpoint**, then proceed to the next phase. After the last phase, proceed to Synthesize.
+
+---
+
+## Checkpoint
+
+Every node transition triggers a checkpoint. Four steps, in order:
+
+### 1. INFORMATION GAP — Do I have what I need?
+
+For each gap:
+- Already have it → use it
+- Know where to get it → invoke tool or query source
+- Don't know where to get it → search
+- Not obtainable → tag the dependent claim LOW and proceed with caveat
+
+### 2. WRITE — Persist state to files
+
+Checklist (every checkpoint, no exceptions):
+- [ ] **plan.md**: Current phase updated? Phase status correct? Decisions recorded? Errors logged?
+- [ ] **findings.md**: All new observations written with confidence tags? Sources listed?
+- [ ] **progress.md**: Actions logged? Files modified listed?
+
+Do not skip because it seems unchanged — verify each one.
+
+### 3. PHASE GATE — Am I done with this phase?
+
+Before starting the next phase:
+- All checklist items for current phase resolved (done or explicitly skipped with reason)
+- Phase status updated: `in_progress` → `complete`
+- Current Phase pointer updated in plan.md
+
+If not changing phase, skip this step.
+
+### 4. TRANSITION — Where next?
+
+Record:
+- **FROM**: which node/phase
+- **TO**: which node/phase
+- **WHY**: what specific finding or completion triggered this
+
+---
+
+## Synthesize
+
+After all phases are complete, combine results into a coherent whole.
+
+- Review each phase's conclusion
+- Identify cross-phase patterns, contradictions, or reinforcements
+- Produce the overall answer to the original OPERATION.md question
+- Ensure every dimension required by the MANIFEST playbook is addressed
+
+---
+
+## Seal
+
+S1. **Verify planning files** — all phases complete in plan.md, all findings captured, progress.md filled
+S2. **Fill OPERATION.md** — set summary, completed_at timestamp, findings section, action items
+S3. **Generate report.html** — user-facing deliverable (see Report Generation below)
+S4. **Mark completed** — set status in OPERATION.md
+
+### Report Generation
+
+Generate `report.html` in the operation root. Single self-contained HTML file, all CSS inlined.
+
+Structure:
+1. **Executive Summary** — 2-3 sentence conclusion
+2. **Key Findings** — important discoveries with data (tables, lists, cards)
+3. **Data & Evidence** — supporting detail
+4. **Methodology** — brief summary of approach (not a dump of planning files)
+
+Requirements:
+- UTF-8 safe — use `create`/`edit` tool, NEVER bash heredoc for non-ASCII content
+- Responsive — readable on mobile and desktop
+- Result-oriented — the reader wants answers, not process replay
+
+---
+
+## Debrief
+
+Choose exactly one handoff:
+- **Notify** — send results to user. Lead with conclusion, include key data, 2-5 sentences.
+- **Dispatch** — hand off follow-up work to another squad via dispatch tool.
+
+Never both. Never neither.
+
+---
+
+## Distill
+
+L1. **Update INTEL.md** in the squad directory — lessons learned, patterns discovered
+L2. **Final verification** — re-read planning files, confirm completeness
+L3. **Terminate**
+
+---
+
+## Confidence Tracking
+
+Every claim carries a confidence level:
+
+| Level | Meaning | Requirement |
+|-------|---------|-------------|
+| HIGH | Very likely correct | Multiple independent sources; survived falsification |
+| MEDIUM | Probably correct | Single reliable source; not yet rigorously tested |
+| LOW | Uncertain | Single non-authoritative source or weak inference |
+| SPECULATIVE | Guess | No direct evidence; extrapolation |
+
+A conclusion's confidence cannot exceed its weakest critical dependency.
+
+Always distinguish observation from inference:
+- Observation: "PE is 13.02 per Yahoo Finance" — directly from source
+- Inference: "The stock is undervalued" — interpretation
+- Never present inference as observation
+
+---
+
+## Evidence Hierarchy
+
+**Primary** (original data, official filings) > **Secondary** (analysis, reporting) > **Tertiary** (aggregation, summaries).
+
+- Conflicting sources: trust the one closer to primary
+- Always note retrieval timestamp
+- Cross-reference critical claims from independent sources
+
+---
+
+## Bias Guards
+
+Active throughout all nodes:
+
+- **Confirmation bias** — seek disconfirming evidence, not just confirming
+- **Anchoring** — don't let the first number dominate; seek multiple reference points
+- **Premature closure** — "What would change my mind?" If unanswerable, think more
+- **Sunk cost** — past effort is irrelevant to what to do next
+- **Availability bias** — recent/vivid ≠ frequent/important; check base rates
+
+---
+
+## Circuit Breaker
+
+If you've attempted the same approach 3+ times without progress:
+
+- **Reframe**: restructure the problem, return to Understand
+- **Skip**: mark as unresolved with rationale, move to next phase
+- **Escalate**: state what was tried and why it failed, end operation
+
+Loops must be visible and justified. Silent looping is not permitted.
+
+---
+
+## Standards
+
+You are fully autonomous. There is no human in the loop. Do not ask for guidance — make decisions and act.
+
+**Be thorough** — use every available tool, follow every lead, cross-reference sources, dig until you hit bedrock.
+
+**Be actionable** — every finding should answer "so what?" Provide concrete recommendations, not vague observations.
+
+**Timestamps**: always UTC, ISO 8601 (`YYYY-MM-DDTHH:MM:SSZ`).
+
+**Shell escaping**: `$` in double-quoted bash is interpreted by bash. Use single quotes to protect `$filter`/`$top` in URLs.
+
+**UTF-8 safety**: always use `create`/`edit` tools for files with non-ASCII content. Never use bash heredoc for Chinese/Japanese/Korean text.


### PR DESCRIPTION
New Protocol design for swat-v2, decoupled from MANIFEST.

## Changes
- **New file**: `blueprints/protocol/PROTOCOL.md` — standalone cognitive framework
- **Decouple from MANIFEST**: no more placeholder merging into AGENTS.md
- **Mandatory Decompose**: after Understand, operator must break task into phases
- **Scientific method per phase**: Hypothesize → Predict → Test → Conclude
- **Single operator role**: remove Captain/Operator split
- **Remove DECOMPOSE output**: complex tasks via multi-operation dispatch
- **Retain core**: Confidence Tracking, Evidence Hierarchy, Bias Guards, Circuit Breaker, 2-Action Rule

## Not included yet
- Hooks, templates, Commander changes, old Protocol removal