### PR TITLE
fix: remove Output Schema from TEMPLATE.md

### DIFF
--- a/blueprints/squads/_framework/TEMPLATE.md
+++ b/blueprints/squads/_framework/TEMPLATE.md
@@ -27,9 +27,3 @@ dependencies:                      # omit block if no dependencies
 
 ## Squad Playbook
 {Domain knowledge, API endpoints, workflows, operational guidance. Use ### subsections to organize content — do not create additional ## sections.}
-
-## Output Schema
-Captain must fill these frontmatter fields in `OPERATION.md` during the operation:
-```yaml
-{field}: # {description}
-```


### PR DESCRIPTION
Output Schema injection was removed in PR #38. TEMPLATE.md still had the section — removing it to stay consistent.