### PR TITLE
feat: Windows support — install.ps1, uninstall.ps1, release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
             goarch: amd64
           - goos: darwin
             goarch: arm64
+          - goos: windows
+            goarch: amd64
 
     steps:
       - uses: actions/checkout@v4
@@ -34,9 +36,13 @@ jobs:
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
-        run: go build -ldflags "-X main.version=${{ github.ref_name }}" -o swat .
+        run: |
+          EXT=""
+          if [ "${{ matrix.goos }}" = "windows" ]; then EXT=".exe"; fi
+          go build -ldflags "-X main.version=${{ github.ref_name }}" -o "swat${EXT}" .
 
-      - name: Package tarball
+      - name: Package (tar.gz for unix)
+        if: matrix.goos != 'windows'
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           PLATFORM="${{ matrix.goos }}-${{ matrix.goarch }}"
@@ -53,11 +59,29 @@ jobs:
           cd staging
           tar -czf "../${TARBALL}" .
 
+      - name: Package (zip for windows)
+        if: matrix.goos == 'windows'
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          PLATFORM="${{ matrix.goos }}-${{ matrix.goarch }}"
+          ZIPFILE="swat-${TAG}-${PLATFORM}.zip"
+
+          mkdir -p staging/plugin staging/skill staging/blueprints/squads/_framework
+
+          cp swat.exe staging/
+          cp plugin/index.ts plugin/package.json plugin/openclaw.plugin.json staging/plugin/
+          cp skill/SKILL.md staging/skill/
+          cp blueprints/OPERATION.md staging/blueprints/
+          cp blueprints/squads/_framework/* staging/blueprints/squads/_framework/
+
+          cd staging
+          zip -r "../${ZIPFILE}" .
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: swat-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: swat-*.tar.gz
+          path: swat-*.*
 
   release:
     needs: build
@@ -71,4 +95,6 @@ jobs:
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
-          files: swat-*.tar.gz
+          files: |
+            swat-*.tar.gz
+            swat-*.zip

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,246 @@
+# SWAT v2 Installer for Windows
+# Usage: irm https://raw.githubusercontent.com/LangSensei/swat-v2/main/install.ps1 | iex
+
+$ErrorActionPreference = "Stop"
+
+$Repo = "LangSensei/swat-v2"
+$SwatHome = Join-Path $env:USERPROFILE ".swat"
+$BinDir = Join-Path $env:USERPROFILE ".local\bin"
+
+# --- Helpers ---
+
+function Info  { param($Msg) Write-Host "[swat] $Msg" -ForegroundColor Cyan }
+function Ok    { param($Msg) Write-Host "[swat] $Msg" -ForegroundColor Green }
+function Err   { param($Msg) Write-Host "[swat] $Msg" -ForegroundColor Red }
+function Warn  { param($Msg) Write-Host "[swat] $Msg" -ForegroundColor Yellow }
+
+# --- Safety: refuse to run as SYSTEM ---
+if ($env:USERNAME -eq "SYSTEM") {
+    Err "Do not run this installer as SYSTEM."
+    exit 1
+}
+
+# --- Detect Platform ---
+
+function Detect-Platform {
+    $arch = if ([Environment]::Is64BitOperatingSystem) { "amd64" } else { "386" }
+    $script:Platform = "windows-$arch"
+    Info "Detected platform: $script:Platform"
+}
+
+# --- Prerequisites ---
+
+function Check-Prereqs {
+    $missing = @()
+    if (-not (Get-Command node -ErrorAction SilentlyContinue)) { $missing += "node" }
+    if (-not (Get-Command npm -ErrorAction SilentlyContinue))  { $missing += "npm" }
+
+    if ($missing.Count -gt 0) {
+        Err "Missing prerequisites: $($missing -join ', ')"
+        exit 1
+    }
+
+    if (-not (Get-Command copilot -ErrorAction SilentlyContinue)) {
+        Warn "GitHub Copilot CLI not found. Required for running squads."
+        Info "  npm install -g @github/copilot"
+    }
+
+    if (Get-Command gh -ErrorAction SilentlyContinue) {
+        $authOk = gh auth status 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Warn "GitHub CLI not authenticated. Run before using SWAT:"
+            Info "  gh auth login"
+        }
+    } else {
+        Warn "GitHub CLI (gh) not found. Required for Copilot CLI auth."
+        Info "  Install: https://cli.github.com"
+    }
+}
+
+# --- Download & Extract ---
+
+function Fetch-Release {
+    $apiUrl = "https://api.github.com/repos/$Repo/releases/latest"
+    $release = Invoke-RestMethod -Uri $apiUrl -UseBasicParsing
+    $tag = $release.tag_name
+
+    if (-not $tag) {
+        Err "Failed to fetch latest release"
+        exit 1
+    }
+
+    $script:Tag = $tag
+    Info "Latest release: $tag"
+
+    # Check if already installed at this version
+    try {
+        $current = & (Join-Path $BinDir "swat.exe") --version 2>$null
+        if ($current -match $tag) {
+            Ok "Already up to date ($tag)"
+            exit 0
+        }
+    } catch {}
+
+    $zipName = "swat-${tag}-${script:Platform}.zip"
+    $dlUrl = "https://github.com/$Repo/releases/download/${tag}/${zipName}"
+    $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) "swat-install-$(Get-Random)"
+    New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
+
+    Info "Downloading $zipName..."
+    Invoke-WebRequest -Uri $dlUrl -OutFile (Join-Path $tmpDir $zipName) -UseBasicParsing
+
+    Info "Extracting..."
+    Expand-Archive -Path (Join-Path $tmpDir $zipName) -DestinationPath $tmpDir -Force
+
+    $script:ExtractDir = $tmpDir
+}
+
+# --- Install ---
+
+function Install-Binary {
+    New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
+    Copy-Item (Join-Path $script:ExtractDir "swat.exe") (Join-Path $BinDir "swat.exe") -Force
+    Ok "Binary installed to $BinDir\swat.exe"
+}
+
+function Install-Plugin {
+    $dest = Join-Path $SwatHome "plugin"
+    if (Test-Path $dest) { Remove-Item -Recurse -Force $dest }
+    New-Item -ItemType Directory -Path $dest -Force | Out-Null
+    Copy-Item (Join-Path $script:ExtractDir "plugin\*") $dest -Recurse -Force
+
+    Info "Installing plugin dependencies..."
+    Push-Location $dest
+    npm install --quiet 2>$null
+    Pop-Location
+    Ok "Plugin installed to $dest"
+}
+
+function Install-Skill {
+    $ocSkills = $null
+    $candidates = @(
+        (Join-Path $env:APPDATA "npm\node_modules\openclaw\skills"),
+        (Join-Path $env:USERPROFILE ".npm-global\lib\node_modules\openclaw\skills")
+    )
+    foreach ($dir in $candidates) {
+        if (Test-Path $dir) { $ocSkills = $dir; break }
+    }
+
+    if (-not $ocSkills) {
+        Info "OpenClaw skills directory not found. Manually copy skill\SKILL.md to your OpenClaw skills dir."
+        return
+    }
+
+    $skillDir = Join-Path $ocSkills "swat"
+    New-Item -ItemType Directory -Path $skillDir -Force | Out-Null
+    Copy-Item (Join-Path $script:ExtractDir "skill\SKILL.md") $skillDir -Force
+    Ok "Skill installed to $skillDir"
+}
+
+function Install-Blueprints {
+    $bp = Join-Path $SwatHome "blueprints"
+    $fwDir = Join-Path $bp "squads\_framework"
+    foreach ($d in @($fwDir, (Join-Path $bp "skills"), (Join-Path $bp "mcps"))) {
+        New-Item -ItemType Directory -Path $d -Force | Out-Null
+    }
+
+    Copy-Item (Join-Path $script:ExtractDir "blueprints\OPERATION.md") $bp -Force
+    Copy-Item (Join-Path $script:ExtractDir "blueprints\squads\_framework\*") $fwDir -Force
+
+    Ok "Framework blueprints installed"
+    Info "Install squads/skills/mcps from the marketplace:"
+    Write-Host "  https://github.com/LangSensei/swat-marketplace"
+}
+
+function Setup-Runtime {
+    New-Item -ItemType Directory -Path (Join-Path $SwatHome "squads") -Force | Out-Null
+}
+
+# --- Post-Install ---
+
+function Register-Plugin {
+    $ocConfig = Join-Path $env:USERPROFILE ".openclaw\openclaw.json"
+    $pluginPath = (Join-Path $SwatHome "plugin") -replace '\\', '/'
+
+    if (-not (Test-Path $ocConfig)) {
+        Info "OpenClaw config not found at $ocConfig"
+        Info "After installing OpenClaw, add the SWAT plugin to your config:"
+        Write-Host ""
+        Write-Host "  plugins.load.paths: [`"$pluginPath`"]"
+        Write-Host "  plugins.entries.swat-mcp-bridge.enabled: true"
+        Write-Host ""
+        Info "Then restart OpenClaw: openclaw gateway restart"
+        return
+    }
+
+    $binPath = (Join-Path $BinDir "swat.exe") -replace '\\', '/'
+
+    try {
+        node -e @"
+const fs = require('fs');
+const cfg = JSON.parse(fs.readFileSync('$($ocConfig -replace '\\', '/')', 'utf8'));
+cfg.plugins = cfg.plugins || {};
+cfg.plugins.load = cfg.plugins.load || {};
+cfg.plugins.load.paths = cfg.plugins.load.paths || [];
+cfg.plugins.entries = cfg.plugins.entries || {};
+if (!cfg.plugins.load.paths.includes('$pluginPath')) {
+    cfg.plugins.load.paths.push('$pluginPath');
+}
+cfg.plugins.entries['swat-mcp-bridge'] = {
+    enabled: true,
+    config: { binaryPath: '$binPath' }
+};
+fs.writeFileSync('$($ocConfig -replace '\\', '/')', JSON.stringify(cfg, null, 2) + '\n');
+"@
+        Ok "Plugin registered in OpenClaw config"
+        Info "Restart OpenClaw to activate: openclaw gateway restart"
+    } catch {
+        Err "Failed to auto-register plugin. Manually add to $ocConfig"
+    }
+}
+
+function Post-Install {
+    # PATH check — add to user PATH if missing
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    if ($userPath -notlike "*$BinDir*") {
+        [Environment]::SetEnvironmentVariable("Path", "$BinDir;$userPath", "User")
+        $env:Path = "$BinDir;$env:Path"
+        Ok "Added $BinDir to user PATH"
+    }
+
+    Register-Plugin
+}
+
+# --- Cleanup ---
+
+function Cleanup {
+    if ($script:ExtractDir -and (Test-Path $script:ExtractDir)) {
+        Remove-Item -Recurse -Force $script:ExtractDir -ErrorAction SilentlyContinue
+    }
+}
+
+# --- Main ---
+
+Write-Host ""
+Info "Installing SWAT v2..."
+Write-Host ""
+
+Detect-Platform
+Check-Prereqs
+Fetch-Release
+Install-Binary
+Install-Plugin
+Install-Skill
+Install-Blueprints
+Setup-Runtime
+Post-Install
+Cleanup
+
+Write-Host ""
+Ok "SWAT v2 installed successfully! 🚀"
+Write-Host ""
+Info "Next steps:"
+Write-Host "  1. Restart OpenClaw:  openclaw gateway restart"
+Write-Host "  2. Install a squad:   Tell your agent: `"browse SWAT marketplace and install a squad`""
+Write-Host "     Or use the tool directly: swat_browse -> swat_install"
+Write-Host ""

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -1,0 +1,159 @@
+# SWAT v2 Uninstaller for Windows
+# Usage: irm https://raw.githubusercontent.com/LangSensei/swat-v2/main/uninstall.ps1 | iex
+
+$ErrorActionPreference = "Stop"
+
+$SwatHome = Join-Path $env:USERPROFILE ".swat"
+$BinDir = Join-Path $env:USERPROFILE ".local\bin"
+
+# --- Helpers ---
+
+function Info  { param($Msg) Write-Host "[swat] $Msg" -ForegroundColor Cyan }
+function Ok    { param($Msg) Write-Host "[swat] $Msg" -ForegroundColor Green }
+function Warn  { param($Msg) Write-Host "[swat] $Msg" -ForegroundColor Yellow }
+function Err   { param($Msg) Write-Host "[swat] $Msg" -ForegroundColor Red }
+
+$Purge = $args -contains "--purge"
+$Yes = $args -contains "--yes"
+
+Write-Host ""
+Write-Host "  SWAT v2 Uninstaller"
+Write-Host "  ==================="
+Write-Host ""
+
+# --- Confirm ---
+
+if (-not $Yes) {
+    Warn "This will remove:"
+    Write-Host "  - Binary:     $BinDir\swat.exe"
+    Write-Host "  - Plugin:     $SwatHome\plugin\"
+    Write-Host "  - Framework:  $SwatHome\blueprints\squads\_framework\, OPERATION.md"
+    Write-Host ""
+    Warn "User data (squads, skills, mcps, schedules, operations) will be KEPT unless you pass --purge"
+    Write-Host ""
+    $confirm = Read-Host "Continue? [y/N]"
+    if ($confirm -notin @("y", "Y")) {
+        Info "Aborted."
+        exit 0
+    }
+}
+
+# --- Remove binary ---
+
+$binPath = Join-Path $BinDir "swat.exe"
+if (Test-Path $binPath) {
+    Remove-Item -Force $binPath
+    Ok "Removed $binPath"
+} else {
+    Info "Binary not found at $binPath (skipped)"
+}
+
+# --- Remove plugin ---
+
+$pluginDir = Join-Path $SwatHome "plugin"
+if (Test-Path $pluginDir) {
+    Remove-Item -Recurse -Force $pluginDir
+    Ok "Removed $pluginDir"
+}
+
+# --- Remove blueprints ---
+
+$bpDir = Join-Path $SwatHome "blueprints"
+if (Test-Path $bpDir) {
+    if ($Purge) {
+        Remove-Item -Recurse -Force $bpDir
+        Ok "Purged $bpDir"
+    } else {
+        $fwDir = Join-Path $bpDir "squads\_framework"
+        if (Test-Path $fwDir) {
+            Remove-Item -Recurse -Force $fwDir
+            Ok "Removed blueprints\squads\_framework\"
+        }
+        $opMd = Join-Path $bpDir "OPERATION.md"
+        if (Test-Path $opMd) {
+            Remove-Item -Force $opMd
+            Ok "Removed blueprints\OPERATION.md"
+        }
+        Info "Kept blueprints\squads\, blueprints\skills\, blueprints\mcps\ (use --purge to remove)"
+    }
+}
+
+# --- Purge runtime data ---
+
+if ($Purge) {
+    foreach ($sub in @("squads", "schedules")) {
+        $d = Join-Path $SwatHome $sub
+        if (Test-Path $d) {
+            Remove-Item -Recurse -Force $d
+            Ok "Purged $d"
+        }
+    }
+    # Remove .swat if empty
+    if ((Test-Path $SwatHome) -and ((Get-ChildItem $SwatHome -Force).Count -eq 0)) {
+        Remove-Item -Force $SwatHome
+        Ok "Removed $SwatHome"
+    }
+} else {
+    if (Test-Path (Join-Path $SwatHome "squads")) {
+        Info "Runtime data kept at $SwatHome\squads\ (use --purge to remove)"
+    }
+}
+
+# --- Remove skill ---
+
+$candidates = @(
+    (Join-Path $env:APPDATA "npm\node_modules\openclaw\skills\swat"),
+    (Join-Path $env:USERPROFILE ".npm-global\lib\node_modules\openclaw\skills\swat")
+)
+foreach ($dir in $candidates) {
+    if (Test-Path $dir) {
+        Remove-Item -Recurse -Force $dir
+        Ok "Removed skill from $dir"
+        break
+    }
+}
+
+# --- Remove from user PATH ---
+
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($userPath -like "*$BinDir*") {
+    $newPath = ($userPath -split ';' | Where-Object { $_ -ne $BinDir }) -join ';'
+    [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+    Ok "Removed $BinDir from user PATH"
+}
+
+# --- Remove OpenClaw plugin config ---
+
+$ocConfig = Join-Path $env:USERPROFILE ".openclaw\openclaw.json"
+if ((Test-Path $ocConfig) -and (Get-Command node -ErrorAction SilentlyContinue)) {
+    try {
+        node -e @"
+const fs = require('fs');
+const cfg = JSON.parse(fs.readFileSync('$($ocConfig -replace '\\', '/')', 'utf8'));
+let changed = false;
+if (cfg.plugins?.load?.paths) {
+    const before = cfg.plugins.load.paths.length;
+    cfg.plugins.load.paths = cfg.plugins.load.paths.filter(p => !p.includes('.swat/plugin') && !p.includes('.swat\\plugin'));
+    if (cfg.plugins.load.paths.length < before) changed = true;
+    if (cfg.plugins.load.paths.length === 0) delete cfg.plugins.load.paths;
+}
+if (cfg.plugins?.entries?.['swat-mcp-bridge']) {
+    delete cfg.plugins.entries['swat-mcp-bridge'];
+    changed = true;
+}
+if (changed) {
+    fs.writeFileSync('$($ocConfig -replace '\\', '/')', JSON.stringify(cfg, null, 2) + '\n');
+}
+"@
+        Ok "Cleaned OpenClaw config"
+    } catch {
+        Info "Could not auto-clean OpenClaw config"
+    }
+}
+
+Write-Host ""
+Ok "SWAT v2 uninstalled."
+if (-not $Purge -and (Test-Path (Join-Path $SwatHome "squads"))) {
+    Info "To fully remove all data: Remove-Item -Recurse -Force $SwatHome"
+}
+Write-Host ""


### PR DESCRIPTION
### Changes
- **install.ps1**: One-liner install via `irm https://raw.githubusercontent.com/LangSensei/swat-v2/main/install.ps1 | iex`
  - Detects platform (windows-amd64)
  - Downloads .zip from GitHub releases
  - Installs binary, plugin, skill, blueprints
  - Registers OpenClaw plugin in config
  - Adds to user PATH
- **uninstall.ps1**: Mirrors uninstall.sh behavior
  - `--yes` for non-interactive, `--purge` for full cleanup
  - Cleans PATH, OpenClaw config, plugin, skill, blueprints
- **Release workflow**: Adds `windows/amd64` build matrix entry
  - Windows builds packaged as `.zip` (not `.tar.gz`)
  - Unix builds unchanged