### PR TITLE
feat: standalone by default, --openclaw for plugin install

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,11 +1,13 @@
 # SWAT v2 Installer for Windows
 # Usage: irm https://raw.githubusercontent.com/LangSensei/swat-v2/main/install.ps1 | iex
+#        powershell -File install.ps1 --openclaw   # also install OpenClaw plugin/skill
 
 $ErrorActionPreference = "Stop"
 
 $Repo = "LangSensei/swat-v2"
 $SwatHome = Join-Path $env:USERPROFILE ".swat"
 $BinDir = Join-Path $env:USERPROFILE ".local\bin"
+$OpenClaw = $args -contains "--openclaw"
 
 # --- Helpers ---
 
@@ -208,7 +210,9 @@ function Post-Install {
         Ok "Added $BinDir to user PATH"
     }
 
-    Register-Plugin
+    if ($OpenClaw) {
+        Register-Plugin
+    }
 }
 
 # --- Cleanup ---
@@ -229,8 +233,10 @@ Detect-Platform
 Check-Prereqs
 Fetch-Release
 Install-Binary
-Install-Plugin
-Install-Skill
+if ($OpenClaw) {
+    Install-Plugin
+    Install-Skill
+}
 Install-Blueprints
 Setup-Runtime
 Post-Install
@@ -240,7 +246,12 @@ Write-Host ""
 Ok "SWAT v2 installed successfully! 🚀"
 Write-Host ""
 Info "Next steps:"
-Write-Host "  1. Restart OpenClaw:  openclaw gateway restart"
-Write-Host "  2. Install a squad:   Tell your agent: `"browse SWAT marketplace and install a squad`""
-Write-Host "     Or use the tool directly: swat_browse -> swat_install"
+if ($OpenClaw) {
+    Write-Host "  1. Restart OpenClaw:  openclaw gateway restart"
+    Write-Host "  2. Install a squad:   Tell your agent: `"browse SWAT marketplace and install a squad`""
+} else {
+    Write-Host "  1. Add to Copilot CLI .mcp.json:"
+    Write-Host "     {`"mcpServers`":{`"swat`":{`"command`":`"$($BinDir -replace '\\','/')/swat.exe`",`"args`":[`"mcp`"]}}}"
+    Write-Host "  2. Install a squad:   swat install <squad-name>"
+}
 Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -3,10 +3,15 @@ set -euo pipefail
 
 # SWAT v2 Installer
 # Usage: curl -fsSL https://raw.githubusercontent.com/LangSensei/swat-v2/main/install.sh | bash
+#        curl -fsSL ... | bash -s -- --openclaw   # also install OpenClaw plugin/skill
 
 REPO="LangSensei/swat-v2"
 SWAT_HOME="$HOME/.swat"
 BIN_DIR="$HOME/.local/bin"
+OPENCLAW=false
+for arg in "$@"; do
+    [[ "$arg" == "--openclaw" ]] && OPENCLAW=true
+done
 
 # --- Safety: refuse to run as root ---
 if [[ "$(id -u)" -eq 0 ]]; then
@@ -258,7 +263,9 @@ post_install() {
         export PATH="$BIN_DIR:$PATH"
     fi
 
-    register_plugin
+    if $OPENCLAW; then
+        register_plugin
+    fi
 }
 
 # --- Cleanup ---
@@ -278,8 +285,10 @@ main() {
     check_prereqs
     fetch_release
     install_binary
-    install_plugin
-    install_skill
+    if $OPENCLAW; then
+        install_plugin
+        install_skill
+    fi
     install_blueprints
     setup_runtime
     post_install
@@ -290,9 +299,15 @@ main() {
 
     echo ""
     info "Next steps:"
-    echo "  1. Restart OpenClaw:  openclaw gateway restart"
-    echo "  2. Install a squad:   Tell your agent: \"browse SWAT marketplace and install a squad\""
-    echo "     Or use the tool directly: swat_browse → swat_install"
+    if $OPENCLAW; then
+        echo "  1. Restart OpenClaw:  openclaw gateway restart"
+        echo "  2. Install a squad:   Tell your agent: \"browse SWAT marketplace and install a squad\""
+        echo "     Or use the tool directly: swat_browse → swat_install"
+    else
+        echo "  1. Add to Copilot CLI .mcp.json:"
+        echo "     {\"mcpServers\":{\"swat\":{\"command\":\"$BIN_DIR/swat\",\"args\":[\"mcp\"]}}}"
+        echo "  2. Install a squad:   swat install <squad-name>"
+    fi
     echo ""
 }
 


### PR DESCRIPTION
Default install is now standalone (binary + blueprints only). Works directly with Copilot CLI via MCP.

```bash
# Standalone (default)
curl -fsSL .../install.sh | bash

# With OpenClaw integration
curl -fsSL .../install.sh | bash -s -- --openclaw
```

Uninstall auto-detects installed components — no flag needed.