### PR TITLE
docs: update README for standalone architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,33 @@
 # SWAT
 
-Deploy your own AI army. SWAT dispatches autonomous squads powered by GitHub Copilot CLI — orchestrated through [OpenClaw](https://github.com/openclaw/openclaw).
+Autonomous multi-agent task execution engine. SWAT dispatches tasks to specialist squads — each running as an independent AI coding agent session.
 
 ## 🚀 Installation
+
+### Linux / macOS
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/LangSensei/swat/main/install.sh | bash
 ```
 
-This will:
-1. Download the latest release for your platform (Linux/macOS, amd64/arm64)
-2. Install the SWAT binary to `~/.local/bin/` (auto-added to PATH in your shell profile)
-3. Set up the OpenClaw bridge plugin at `~/.swat/plugin/`
-4. Install framework blueprints to `~/.swat/blueprints/`
-5. Auto-register the plugin in your OpenClaw config
+### Windows
 
-Then restart OpenClaw and you're ready to go.
+```powershell
+irm https://raw.githubusercontent.com/LangSensei/swat/main/install.ps1 | iex
+```
+
+This will:
+1. Download the latest release for your platform
+2. Install the SWAT binary to `~/.local/bin/` (auto-added to PATH)
+3. Install framework blueprints to `~/.swat/blueprints/`
+
+### OpenClaw Integration (Optional)
+
+If you use [OpenClaw](https://github.com/openclaw/openclaw), install the bridge plugin separately:
+
+```bash
+# See https://github.com/LangSensei/swat-openclaw
+```
 
 ## 🗑️ Uninstallation
 
@@ -23,57 +35,67 @@ Then restart OpenClaw and you're ready to go.
 curl -fsSL https://raw.githubusercontent.com/LangSensei/swat/main/uninstall.sh | bash
 ```
 
-Add `--purge` to also remove runtime data (operation history, intel).
+Add `--purge` to also remove runtime data (operation history).
 
 ## 🎮 Usage
 
-SWAT is controlled entirely through OpenClaw — no CLI needed. Just chat naturally, or use the 10 built-in tools:
+SWAT exposes 10 MCP tools. Configure your agent to connect:
 
-### Operations
+### MCP Configuration
+
+```json
+{
+  "mcpServers": {
+    "swat": {
+      "command": "swat",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+### Tools
+
+#### Operations
 - `swat_dispatch` — Dispatch a task (auto-classified to the right squad)
 - `swat_ops` — List operations with filters (status/since/limit/offset)
 - `swat_cancel` — Cancel a running operation
 
-### Squads
+#### Squads
 - `swat_squads` — List installed squads
 - `swat_squad_browse` — Browse the marketplace
 - `swat_squad_install` — Install a squad from the marketplace
 - `swat_squad_uninstall` — Uninstall a squad
 - `swat_squad_update` — Update a squad to the latest marketplace version
 
-### Schedule
+#### Schedule
 - `swat_schedule_create` — Create a recurring task (zero LLM cost)
 - `swat_schedules` — List all schedules
 - `swat_schedule_delete` — Delete a schedule
 
-For detailed tool usage and monitoring patterns, see [`skill/SKILL.md`](skill/SKILL.md).
-
 ### CLI Flags
-
-The `swat` binary supports the following flags:
 
 | Flag | Description |
 |------|-------------|
-| `--version` | Print the installed version (`swat <version>`) and exit |
+| `--version` | Print the installed version and exit |
 | `--mcp-only` | Start only the MCP server — skip the background commander loop |
 
 ## 🧠 Architecture
 
 ```
-OpenClaw (HQ) → Bridge Plugin → SWAT Commander (Go MCP) → Squads (Copilot CLI)
+Agent → MCP → SWAT Commander (Go) → Squads (AI coding agent sessions)
 ```
 
-1. **OpenClaw** — Your interface. Chat to dispatch and monitor tasks.
-2. **Commander** — Go MCP server. Handles dispatch, workspace composition, dependency resolution, scheduling, and completion scanning.
-3. **Squads** — Specialist agents. Each runs as an independent Copilot CLI process with its own skills, MCP tools, and protocol.
+1. **Commander** — Go MCP server. Handles dispatch, workspace composition, dependency resolution, scheduling, and completion scanning.
+2. **Squads** — Specialist agents. Each runs as an independent coding agent session with its own skills, MCP tools, and protocol.
 
 ### How It Works
 
 1. You dispatch a task (Commander auto-classifies to the right squad)
 2. Commander provisions the workspace — copies squad snapshot to `.squad/`, skill hooks to `.github/hooks/`, skill content to `.github/skills/`, resolves MCP dependencies, writes AGENTS.md (protocol)
-3. Copilot CLI launches in the operation directory, reads AGENTS.md + OPERATION.md
+3. A coding agent session launches in the operation directory, reads AGENTS.md + OPERATION.md
 4. Commander's background loop scans for completion (OPERATION.md status + report.html)
-5. Results surface through OpenClaw
+5. Results surface through your agent
 
 ### Scheduler
 
@@ -92,8 +114,7 @@ Built-in Go cron scheduler for recurring tasks — zero LLM cost:
 │   ├── squads/
 │   │   ├── _framework/            # Core protocol (versioned with binary)
 │   │   │   ├── PROTOCOL.md
-│   │   │   ├── TEMPLATE.md
-│   │   │   └── INTEL.md
+│   │   │   └── TEMPLATE.md
 │   │   └── <squad>/               # Squad blueprints
 │   │       └── MANIFEST.md
 │   ├── skills/                    # Shared skills
@@ -102,7 +123,6 @@ Built-in Go cron scheduler for recurring tasks — zero LLM cost:
 ├── squads/                        # Runtime data
 │   ├── _unclassified/             # Operations before squad assignment
 │   └── <squad>/
-│       ├── INTEL.md               # Persistent cross-operation knowledge
 │       └── operations/
 │           └── <id>/              # Operation workspace
 │               ├── OPERATION.md
@@ -111,21 +131,19 @@ Built-in Go cron scheduler for recurring tasks — zero LLM cost:
 │               ├── report.html
 │               ├── .squad/        # Squad blueprint snapshot (read-only)
 │               └── .github/
-│                   ├── hooks/     # Skill hooks (Copilot CLI native)
-│                   └── skills/    # Skill content (SKILL.md + templates)
+│                   ├── hooks/     # Skill hooks
+│                   └── skills/    # Skill content
 │
-├── schedules/                     # Schedule definitions (JSON)
-│   └── <id>.json
-│
-└── plugin/                        # OpenClaw bridge plugin
+└── schedules/                     # Schedule definitions (JSON)
+    └── <id>.json
 ```
 
 ## 🛠️ Prerequisites
 
-- Linux or macOS
+- Linux, macOS, or Windows
 - [GitHub Copilot CLI](https://www.npmjs.com/package/@github/copilot) (`npm install -g @github/copilot`)
 - Node.js 18+
-- [OpenClaw](https://github.com/openclaw/openclaw)
+- [GitHub CLI](https://cli.github.com) (authenticated)
 
 ## 🔨 Building from Source
 
@@ -134,6 +152,11 @@ go build -o swat .   # Go 1.24+
 # With version injection:
 go build -ldflags "-X main.version=v1.0.0" -o swat .
 ```
+
+## 📦 Related Projects
+
+- [swat-marketplace](https://github.com/LangSensei/swat-marketplace) — Squads, skills, and MCPs
+- [swat-openclaw](https://github.com/LangSensei/swat-openclaw) — OpenClaw integration (plugin + skill)
 
 ## 📄 License
 


### PR DESCRIPTION
Major README rewrite after swat-v2 → swat rename and OpenClaw decoupling.

### Changes
- Remove OpenClaw as a dependency — SWAT is standalone
- Add Windows install instructions (PowerShell)
- Add MCP configuration section for direct agent integration
- Remove `plugin/` and `INTEL.md` from directory structure
- Generic 'coding agent session' instead of specific CLI names
- Add Related Projects section linking marketplace + swat-openclaw