### PR TITLE
fix: git init in operation dir for Copilot CLI hook discovery

### DIFF
--- a/commander/dispatch.go
+++ b/commander/dispatch.go
@@ -275,5 +275,10 @@ func (c *Commander) provision(op *Operation, opDir string) error {
 		}
 	}
 
+	// git init — Copilot CLI requires a git repo to discover .github/hooks/
+	gitInit := exec.Command("git", "init")
+	gitInit.Dir = opDir
+	gitInit.Run() // best-effort; hooks won't fire without it but operation can still proceed
+
 	return nil
 }


### PR DESCRIPTION
Copilot CLI requires a `.git/` directory to discover and execute `.github/hooks/*.json` scripts.

**Root cause:** Without git init, hooks are loaded into memory ('5 hooks loaded') but never actually executed at runtime.

**Fix:** Add `git init` at end of provision. Best-effort — if git is unavailable, operation proceeds without hooks.

**Tested on Linux:** All 5 hook types (sessionStart, preToolUse, postToolUse, agentStop, errorOccurred) fire correctly after git init.