### PR TITLE
fix: use GitHub auth token for marketplace API calls

### DIFF
--- a/commander/squads.go
+++ b/commander/squads.go
@@ -6,8 +6,10 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 )
 
 const marketplaceAPI = "https://api.github.com/repos/LangSensei/swat-marketplace"
@@ -324,6 +326,37 @@ func (c *Commander) cleanOrphans() {
 
 // --- GitHub API helpers ---
 
+// ghToken resolves a GitHub token once: GITHUB_TOKEN env → gh auth token CLI.
+var (
+	ghTokenOnce  sync.Once
+	ghTokenValue string
+)
+
+func resolveGHToken() string {
+	ghTokenOnce.Do(func() {
+		if t := os.Getenv("GITHUB_TOKEN"); t != "" {
+			ghTokenValue = t
+			return
+		}
+		if out, err := exec.Command("gh", "auth", "token").Output(); err == nil {
+			ghTokenValue = strings.TrimSpace(string(out))
+		}
+	})
+	return ghTokenValue
+}
+
+// ghHTTPGet performs an HTTP GET with optional GitHub auth.
+func ghHTTPGet(url string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if token := resolveGHToken(); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return http.DefaultClient.Do(req)
+}
+
 type ghEntry struct {
 	Name string `json:"name"`
 	Type string `json:"type"` // "file" or "dir"
@@ -332,7 +365,7 @@ type ghEntry struct {
 
 func ghListDir(path string) ([]ghEntry, error) {
 	url := fmt.Sprintf("%s/contents/%s", marketplaceAPI, path)
-	resp, err := http.Get(url)
+	resp, err := ghHTTPGet(url)
 	if err != nil {
 		return nil, err
 	}
@@ -354,7 +387,7 @@ func ghListDir(path string) ([]ghEntry, error) {
 
 func ghGetFile(path string) ([]byte, error) {
 	url := fmt.Sprintf("https://raw.githubusercontent.com/LangSensei/swat-marketplace/main/%s", path)
-	resp, err := http.Get(url)
+	resp, err := ghHTTPGet(url)
 	if err != nil {
 		return nil, err
 	}

--- a/commander/squads.go
+++ b/commander/squads.go
@@ -374,6 +374,9 @@ func ghListDir(path string) ([]ghEntry, error) {
 	if resp.StatusCode == 404 {
 		return nil, fmt.Errorf("path %q not found in marketplace", path)
 	}
+	if resp.StatusCode == 403 {
+		return nil, fmt.Errorf("GitHub API rate limited (403) — install gh CLI or set GITHUB_TOKEN")
+	}
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("GitHub API returned %d", resp.StatusCode)
 	}


### PR DESCRIPTION
## Problem
All GitHub API calls in `squads.go` used unauthenticated `http.Get`, hitting the anonymous rate limit of 60 requests/hour.

## Fix
Added `ghHTTPGet()` that resolves a GitHub token via:
1. `GITHUB_TOKEN` environment variable
2. `gh auth token` CLI (uses machine-cached credentials)

Token is resolved once (sync.Once) and reused. Authenticated requests get 5,000 requests/hour.

## Changes
- `commander/squads.go`: Added `resolveGHToken()`, `ghHTTPGet()`; replaced both `http.Get` calls