### PR TITLE
fix: processAlive returns false on Windows

### DIFF
--- a/commander/collect.go
+++ b/commander/collect.go
@@ -2,9 +2,7 @@ package commander
 
 import (
 	"log"
-	"os"
 	"path/filepath"
-	"syscall"
 	"time"
 )
 
@@ -87,18 +85,4 @@ func (c *Commander) ShouldReview() bool {
 	}
 	return false
 }
-
-func processAlive(pid int) bool {
-	if pid == 0 {
-		return false
-	}
-	// Signal(nil) broken in Go 1.24: pidfd path returns "unsupported signal type".
-	// Signal(syscall.Signal(0)) correctly maps to kill(pid, 0) via pidfd_send_signal.
-	p, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	return p.Signal(syscall.Signal(0)) == nil
-}
-
 

--- a/commander/process_unix.go
+++ b/commander/process_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package commander
+
+import (
+	"os"
+	"syscall"
+)
+
+func processAlive(pid int) bool {
+	if pid == 0 {
+		return false
+	}
+	// Signal(syscall.Signal(0)) maps to kill(pid, 0) via pidfd_send_signal.
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return p.Signal(syscall.Signal(0)) == nil
+}

--- a/commander/process_windows.go
+++ b/commander/process_windows.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package commander
+
+import "golang.org/x/sys/windows"
+
+func processAlive(pid int) bool {
+	if pid == 0 {
+		return false
+	}
+	const STILL_ACTIVE = 259
+	handle, err := windows.OpenProcess(
+		windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid),
+	)
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(handle)
+
+	var exitCode uint32
+	if err := windows.GetExitCodeProcess(handle, &exitCode); err != nil {
+		return false
+	}
+	return exitCode == STILL_ACTIVE
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/LangSensei/swat
 
 go 1.24.1
+
+require golang.org/x/sys v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
+golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=


### PR DESCRIPTION
Split `processAlive` into platform-specific files:
- **Unix** (`process_unix.go`): keep `kill(pid, 0)` via `syscall.Signal(0)`
- **Windows** (`process_windows.go`): use `OpenProcess` + `GetExitCodeProcess` (`STILL_ACTIVE=259`)

`Signal(0)` is not supported on Windows, causing `processAlive` to always return `false`. This made the collector mark running operations as `failed` while copilot was still executing.

Adds `golang.org/x/sys` dependency for `windows` package.