### PR TITLE
fix: install binary to ~/.swat/bin instead of ~/.local/bin

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -5,7 +5,7 @@ $ErrorActionPreference = "Stop"
 
 $Repo = "LangSensei/swat"
 $SwatHome = Join-Path $env:USERPROFILE ".swat"
-$BinDir = Join-Path $env:USERPROFILE ".local\bin"
+$BinDir = Join-Path $env:USERPROFILE ".swat\bin"
 
 # --- Helpers ---
 

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 REPO="LangSensei/swat"
 SWAT_HOME="$HOME/.swat"
-BIN_DIR="$HOME/.local/bin"
+BIN_DIR="$HOME/.swat/bin"
 
 # --- Safety: refuse to run as root ---
 if [[ "$(id -u)" -eq 0 ]]; then

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -4,7 +4,7 @@
 $ErrorActionPreference = "Stop"
 
 $SwatHome = Join-Path $env:USERPROFILE ".swat"
-$BinDir = Join-Path $env:USERPROFILE ".local\bin"
+$BinDir = Join-Path $env:USERPROFILE ".swat\bin"
 
 function Info  { param($Msg) Write-Host "[swat] $Msg" -ForegroundColor Cyan }
 function Ok    { param($Msg) Write-Host "[swat] $Msg" -ForegroundColor Green }

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Usage: curl -fsSL https://raw.githubusercontent.com/LangSensei/swat/main/uninstall.sh | bash
 
 SWAT_HOME="$HOME/.swat"
-BIN_DIR="$HOME/.local/bin"
+BIN_DIR="$HOME/.swat/bin"
 
 info()  { echo -e "\033[0;36m[swat]\033[0m $*"; }
 ok()    { echo -e "\033[0;32m[swat]\033[0m $*"; }


### PR DESCRIPTION
## Problem

install.sh places binary at ~/.local/bin/swat, but /usr/local/bin has higher PATH priority. On multi-user systems an older version at /usr/local/bin/swat shadows the new one.

## Fix

Change BIN_DIR from ~/.local/bin to ~/.swat/bin in both install.sh and uninstall.sh.