### PR TITLE
feat: add GeminiAdapter to commander/runtime/

### DIFF
--- a/commander/runtime/gemini.go
+++ b/commander/runtime/gemini.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/gofrs/flock"
 )
 
 // GeminiAdapter implements RuntimeAdapter for the Google Gemini CLI.
@@ -44,6 +46,12 @@ func (a *GeminiAdapter) PrepareWorkspace(opDir string, _ Phase) error {
 	}
 
 	trustedPath := filepath.Join(geminiDir, "trustedFolders.json")
+
+	fileLock := flock.New(trustedPath + ".lock")
+	if err := fileLock.Lock(); err != nil {
+		return fmt.Errorf("acquire lock: %w", err)
+	}
+	defer fileLock.Unlock()
 
 	folders := make(map[string]string)
 	data, err := os.ReadFile(trustedPath)

--- a/commander/runtime/gemini.go
+++ b/commander/runtime/gemini.go
@@ -1,0 +1,76 @@
+package runtime
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// GeminiAdapter implements RuntimeAdapter for the Google Gemini CLI.
+type GeminiAdapter struct {
+	BaseProvisioner
+}
+
+// NewGeminiAdapter creates a properly initialized GeminiAdapter.
+func NewGeminiAdapter() *GeminiAdapter {
+	return &GeminiAdapter{
+		BaseProvisioner: BaseProvisioner{
+			dotDir:        ".gemini",
+			agentFileName: "GEMINI.md",
+			mcpConfigPath: ".gemini/settings.json",
+		},
+	}
+}
+
+// Name returns "gemini".
+func (a *GeminiAdapter) Name() string { return "gemini" }
+
+// PrepareWorkspace registers the operation directory as a trusted folder in
+// ~/.gemini/trustedFolders.json for all phases. It reads the existing JSON
+// object (or creates {} if not found), adds "<opDir>": "TRUST_FOLDER", and
+// writes back. Paths use forward slashes.
+func (a *GeminiAdapter) PrepareWorkspace(opDir string, _ Phase) error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("get home dir: %w", err)
+	}
+
+	geminiDir := filepath.Join(homeDir, ".gemini")
+	if err := os.MkdirAll(geminiDir, 0755); err != nil {
+		return fmt.Errorf("create ~/.gemini: %w", err)
+	}
+
+	trustedPath := filepath.Join(geminiDir, "trustedFolders.json")
+
+	folders := make(map[string]string)
+	data, err := os.ReadFile(trustedPath)
+	if err == nil {
+		if err := json.Unmarshal(data, &folders); err != nil {
+			return fmt.Errorf("parse trustedFolders.json: %w", err)
+		}
+	}
+
+	// Use forward slashes for the key
+	key := strings.ReplaceAll(opDir, "\\", "/")
+	folders[key] = "TRUST_FOLDER"
+
+	out, err := json.MarshalIndent(folders, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal trustedFolders.json: %w", err)
+	}
+	if err := os.WriteFile(trustedPath, out, 0644); err != nil {
+		return fmt.Errorf("write trustedFolders.json: %w", err)
+	}
+
+	return nil
+}
+
+// BuildCommand constructs the Gemini CLI command with standard flags.
+func (a *GeminiAdapter) BuildCommand(prompt, workDir string) *exec.Cmd {
+	cmd := exec.Command("gemini", "-p", prompt, "--yolo", "--output-format", "json")
+	cmd.Dir = workDir
+	return cmd
+}

--- a/commander/runtime/gemini.go
+++ b/commander/runtime/gemini.go
@@ -47,7 +47,7 @@ func (a *GeminiAdapter) PrepareWorkspace(opDir string, _ Phase) error {
 
 	trustedPath := filepath.Join(geminiDir, "trustedFolders.json")
 
-	fileLock := flock.New(trustedPath + ".lock")
+	fileLock := flock.New(trustedPath)
 	if err := fileLock.Lock(); err != nil {
 		return fmt.Errorf("acquire lock: %w", err)
 	}

--- a/commander/runtime/runtime.go
+++ b/commander/runtime/runtime.go
@@ -64,6 +64,8 @@ func New(name string) (RuntimeAdapter, error) {
 	switch name {
 	case "copilot":
 		return NewCopilotAdapter(), nil
+	case "gemini":
+		return NewGeminiAdapter(), nil
 	default:
 		return nil, fmt.Errorf("unknown runtime: %q", name)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.24.1
 
 require golang.org/x/sys v0.37.0
 
-require github.com/gofrs/flock v0.13.0 // indirect
+require github.com/gofrs/flock v0.13.0

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,6 @@ module github.com/LangSensei/swat
 
 go 1.24.1
 
-require golang.org/x/sys v0.33.0
+require golang.org/x/sys v0.37.0
+
+require github.com/gofrs/flock v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
 github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
-golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
-golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
 golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,6 @@
+github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
+github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
+golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
## What
Add `GeminiAdapter` as the second `RuntimeAdapter` implementation in `commander/runtime/`.

## Why
Validates the multi-runtime adapter pattern established by CopilotAdapter (PR #52). Enables Gemini CLI as an alternative agent runtime for SWAT operations.

## Changes
- `commander/runtime/gemini.go`: New `GeminiAdapter` struct embedding `BaseProvisioner`, implementing `Name()`, `PrepareWorkspace()`, and `BuildCommand()`
- `commander/runtime/runtime.go`: Added `"gemini"` case to `New()` factory function

### GeminiAdapter specifics
| Method | Value |
|--------|-------|
| `Name()` | `"gemini"` |
| `DotDir()` | `".gemini"` |
| `AgentFileName()` | `"GEMINI.md"` |
| `MCPConfigPath()` | `".gemini/settings.json"` |
| `PrepareWorkspace` | Registers op-dir in `~/.gemini/trustedFolders.json` (all phases) |
| `BuildCommand` | `gemini -p "prompt" --yolo --output-format json` (no `--effort` flag) |

## How to Test
```bash
go build -o /dev/null .
go vet ./...
```