### PR TITLE
refactor: rename RuntimeAdapter methods to Compose*, add ComposeHooks

### DIFF
--- a/commander/compose.go
+++ b/commander/compose.go
@@ -2,7 +2,6 @@ package commander
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -88,41 +87,35 @@ func (c *Commander) resolveMCPDependencies(squad string) []string {
 	return result
 }
 
-// composeMCPConfig builds .mcp.json from individual MCP config files.
+// composeMCPConfig builds a map of MCP server entries from individual config files.
 // runtimeName and notifyBackend are injected as --runtime and --notify flags
 // into the "swat" server args, if present.
-func composeMCPConfig(swatRoot, runtimeName, notifyBackend string, mcps []string) string {
+func composeMCPConfig(swatRoot, runtimeName, notifyBackend string, mcps []string) map[string]interface{} {
 	mcpsDir := filepath.Join(swatRoot, "blueprints", "mcps")
-	servers := make(map[string]string)
+	servers := make(map[string]interface{})
 	for _, name := range mcps {
 		path := filepath.Join(mcpsDir, name+".json")
 		data, err := os.ReadFile(path)
 		if err != nil {
 			continue
 		}
-		raw := strings.TrimSpace(string(data))
+
+		var parsed interface{}
+		if err := json.Unmarshal(data, &parsed); err != nil {
+			continue
+		}
 
 		// Inject --runtime and --notify into the swat server entry
 		if name == "swat" {
+			raw := strings.TrimSpace(string(data))
 			raw = injectSwatArgs(raw, runtimeName, notifyBackend)
+			if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+				continue
+			}
 		}
-		servers[name] = raw
+		servers[name] = parsed
 	}
-	if len(servers) == 0 {
-		return ""
-	}
-	var sb strings.Builder
-	sb.WriteString("{\n  \"mcpServers\": {\n")
-	i := 0
-	for name, config := range servers {
-		if i > 0 {
-			sb.WriteString(",\n")
-		}
-		sb.WriteString(fmt.Sprintf("    %q: %s", name, config))
-		i++
-	}
-	sb.WriteString("\n  }\n}\n")
-	return sb.String()
+	return servers
 }
 
 // injectSwatArgs adds --runtime and --notify flags to a swat MCP server JSON config.

--- a/commander/dispatch.go
+++ b/commander/dispatch.go
@@ -259,7 +259,9 @@ func (c *Commander) provision(rt runtime.RuntimeAdapter, op *Operation, opDir st
 	resolvedMCPs := c.resolveMCPDependencies(op.Squad)
 	servers := composeMCPConfig(c.SwatRoot, c.RuntimeName, c.NotifyBackend, resolvedMCPs)
 	if len(servers) > 0 {
-		rt.ComposeMCPConfig(opDir, servers)
+		if err := rt.ComposeMCPConfig(opDir, servers); err != nil {
+			return err
+		}
 	}
 
 	// Copy skill content (resolve dependencies recursively)

--- a/commander/dispatch.go
+++ b/commander/dispatch.go
@@ -257,11 +257,9 @@ func (c *Commander) provision(rt runtime.RuntimeAdapter, op *Operation, opDir st
 
 	// Compose MCP config from resolved MCP dependencies
 	resolvedMCPs := c.resolveMCPDependencies(op.Squad)
-	if len(resolvedMCPs) > 0 {
-		mcpConfig := composeMCPConfig(c.SwatRoot, c.RuntimeName, c.NotifyBackend, resolvedMCPs)
-		if mcpConfig != "" {
-			rt.ComposeMCPConfig(opDir, mcpConfig)
-		}
+	servers := composeMCPConfig(c.SwatRoot, c.RuntimeName, c.NotifyBackend, resolvedMCPs)
+	if len(servers) > 0 {
+		rt.ComposeMCPConfig(opDir, servers)
 	}
 
 	// Copy skill content (resolve dependencies recursively)

--- a/commander/dispatch.go
+++ b/commander/dispatch.go
@@ -246,12 +246,12 @@ func (c *Commander) provision(rt runtime.RuntimeAdapter, op *Operation, opDir st
 	if err != nil {
 		return fmt.Errorf("read protocol: %w", err)
 	}
-	if err := rt.WriteAgentFile(opDir, protocol); err != nil {
+	if err := rt.ComposeAgentFile(opDir, protocol); err != nil {
 		return err
 	}
 
 	// Copy squad blueprint snapshot to .squad/ (read-only reference)
-	if err := rt.CopySquad(squadBP, opDir); err != nil {
+	if err := rt.ComposeSquad(squadBP, opDir); err != nil {
 		return err
 	}
 
@@ -260,14 +260,19 @@ func (c *Commander) provision(rt runtime.RuntimeAdapter, op *Operation, opDir st
 	if len(resolvedMCPs) > 0 {
 		mcpConfig := composeMCPConfig(c.SwatRoot, c.RuntimeName, c.NotifyBackend, resolvedMCPs)
 		if mcpConfig != "" {
-			rt.WriteMCPConfig(opDir, mcpConfig)
+			rt.ComposeMCPConfig(opDir, mcpConfig)
 		}
 	}
 
-	// Copy skills (resolve dependencies recursively)
+	// Copy skill content (resolve dependencies recursively)
 	skillsRoot := filepath.Join(c.SwatRoot, "blueprints", "skills")
 	resolvedSkills := c.resolveDependencies(op.Squad)
-	if err := rt.CopySkills(skillsRoot, resolvedSkills, opDir); err != nil {
+	if err := rt.ComposeSkills(skillsRoot, resolvedSkills, opDir); err != nil {
+		return err
+	}
+
+	// Copy runtime-specific hooks from resolved skills
+	if err := rt.ComposeHooks(skillsRoot, resolvedSkills, opDir); err != nil {
 		return err
 	}
 

--- a/commander/runtime/base.go
+++ b/commander/runtime/base.go
@@ -1,16 +1,17 @@
 package runtime
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
+"encoding/json"
+"fmt"
+"os"
+"path/filepath"
 )
 
 // BaseProvisioner provides shared provisioning logic used across all runtime adapters.
 type BaseProvisioner struct {
-	dotDir        string
-	agentFileName string
-	mcpConfigPath string
+dotDir        string
+agentFileName string
+mcpConfigPath string
 }
 
 // DotDir returns the runtime-specific dot directory (e.g. ".github").
@@ -22,87 +23,117 @@ func (b *BaseProvisioner) AgentFileName() string { return b.agentFileName }
 // MCPConfigPath returns the runtime-specific MCP config path (e.g. ".mcp.json").
 func (b *BaseProvisioner) MCPConfigPath() string { return b.mcpConfigPath }
 
-// WriteAgentFile writes the agent instruction content to the appropriate file in opDir.
-func (b *BaseProvisioner) WriteAgentFile(opDir string, content []byte) error {
-	dest := filepath.Join(opDir, b.agentFileName)
-	if err := os.WriteFile(dest, content, 0644); err != nil {
-		return fmt.Errorf("write %s: %w", b.agentFileName, err)
-	}
-	return nil
+// ComposeAgentFile writes the agent instruction content to the appropriate file in opDir.
+func (b *BaseProvisioner) ComposeAgentFile(opDir string, content []byte) error {
+dest := filepath.Join(opDir, b.agentFileName)
+if err := os.WriteFile(dest, content, 0644); err != nil {
+return fmt.Errorf("write %s: %w", b.agentFileName, err)
+}
+return nil
 }
 
-// WriteMCPConfig writes the MCP configuration JSON to the appropriate path in opDir.
-func (b *BaseProvisioner) WriteMCPConfig(opDir string, content string) error {
-	dest := filepath.Join(opDir, b.mcpConfigPath)
-	if err := os.WriteFile(dest, []byte(content), 0644); err != nil {
-		return fmt.Errorf("write %s: %w", b.mcpConfigPath, err)
-	}
-	return nil
+// ComposeMCPConfig merges incoming MCP configuration JSON into the existing
+// config file at MCPConfigPath(). If the file doesn't exist, it is created.
+// The incoming content's mcpServers are merged into the existing object so
+// that multiple calls append servers rather than overwrite.
+func (b *BaseProvisioner) ComposeMCPConfig(opDir string, content string) error {
+dest := filepath.Join(opDir, b.mcpConfigPath)
+
+// Ensure parent directory exists
+if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+return fmt.Errorf("create dir for %s: %w", b.mcpConfigPath, err)
 }
 
-// CopySquad copies the squad blueprint snapshot into opDir/.squad/.
-func (b *BaseProvisioner) CopySquad(squadBPDir, opDir string) error {
-	destDir := filepath.Join(opDir, ".squad")
-	if err := copyDir(squadBPDir, destDir); err != nil {
-		return fmt.Errorf("copy squad snapshot: %w", err)
-	}
-	return nil
+// Parse incoming config
+var incoming map[string]interface{}
+if err := json.Unmarshal([]byte(content), &incoming); err != nil {
+return fmt.Errorf("parse incoming MCP config: %w", err)
 }
 
-// CopySkills copies resolved skills into the runtime's dotDir.
-// Skill content (excluding hooks/) goes to <dotDir>/skills/<name>/.
-// Skill hooks/ are merged into <dotDir>/hooks/.
-func (b *BaseProvisioner) CopySkills(skillsRoot string, resolvedSkills []string, opDir string) error {
-	destSkillsDir := filepath.Join(opDir, b.dotDir, "skills")
-	destHooksDir := filepath.Join(opDir, b.dotDir, "hooks")
-	hooksExclude := map[string]bool{"hooks": true}
+// Read existing config (or start with empty object)
+existing := make(map[string]interface{})
+if data, err := os.ReadFile(dest); err == nil {
+if err := json.Unmarshal(data, &existing); err != nil {
+return fmt.Errorf("parse existing %s: %w", b.mcpConfigPath, err)
+}
+}
 
-	for _, skill := range resolvedSkills {
-		srcSkill := filepath.Join(skillsRoot, skill)
-		if _, err := os.Stat(srcSkill); err != nil {
-			continue
-		}
+// Merge mcpServers
+existingServers, _ := existing["mcpServers"].(map[string]interface{})
+if existingServers == nil {
+existingServers = make(map[string]interface{})
+}
+if incomingServers, ok := incoming["mcpServers"].(map[string]interface{}); ok {
+for k, v := range incomingServers {
+existingServers[k] = v
+}
+}
+existing["mcpServers"] = existingServers
 
-		// Copy skill content excluding hooks/
-		if err := copyDirExclude(srcSkill, filepath.Join(destSkillsDir, skill), hooksExclude); err != nil {
-			return fmt.Errorf("copy skill %s: %w", skill, err)
-		}
+out, err := json.MarshalIndent(existing, "", "  ")
+if err != nil {
+return fmt.Errorf("marshal %s: %w", b.mcpConfigPath, err)
+}
+out = append(out, '\n')
+if err := os.WriteFile(dest, out, 0644); err != nil {
+return fmt.Errorf("write %s: %w", b.mcpConfigPath, err)
+}
+return nil
+}
 
-		// Copy skill hooks if they exist
-		srcHooks := filepath.Join(srcSkill, "hooks")
-		if info, err := os.Stat(srcHooks); err == nil && info.IsDir() {
-			if err := copyDir(srcHooks, destHooksDir); err != nil {
-				return fmt.Errorf("copy hooks for skill %s: %w", skill, err)
-			}
-		}
-	}
-	return nil
+// ComposeSquad copies the squad blueprint snapshot into opDir/.squad/.
+func (b *BaseProvisioner) ComposeSquad(squadBPDir, opDir string) error {
+destDir := filepath.Join(opDir, ".squad")
+if err := copyDir(squadBPDir, destDir); err != nil {
+return fmt.Errorf("copy squad snapshot: %w", err)
+}
+return nil
+}
+
+// ComposeSkills copies resolved skill content into the runtime's dotDir.
+// Only skill content (SKILL.md, etc.) is copied to <dotDir>/skills/<name>/.
+// The hooks/ subdirectory is excluded entirely — hooks are handled by ComposeHooks.
+func (b *BaseProvisioner) ComposeSkills(skillsRoot string, resolvedSkills []string, opDir string) error {
+destSkillsDir := filepath.Join(opDir, b.dotDir, "skills")
+hooksExclude := map[string]bool{"hooks": true}
+
+for _, skill := range resolvedSkills {
+srcSkill := filepath.Join(skillsRoot, skill)
+if _, err := os.Stat(srcSkill); err != nil {
+continue
+}
+
+if err := copyDirExclude(srcSkill, filepath.Join(destSkillsDir, skill), hooksExclude); err != nil {
+return fmt.Errorf("copy skill %s: %w", skill, err)
+}
+}
+return nil
 }
 
 // copyDir recursively copies a directory tree.
 func copyDir(src, dst string) error {
-	return copyDirExclude(src, dst, nil)
+return copyDirExclude(src, dst, nil)
 }
 
 // copyDirExclude recursively copies a directory tree, skipping directories whose
 // base name appears in the exclude set.
 func copyDirExclude(src, dst string, exclude map[string]bool) error {
-	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		rel, _ := filepath.Rel(src, path)
-		if info.IsDir() && exclude[info.Name()] && rel != "." {
-			return filepath.SkipDir
-		}
-		target := filepath.Join(dst, rel)
-		if info.IsDir() {
-			return os.MkdirAll(target, 0755)
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(target, data, info.Mode())
-	})
+return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+if err != nil {
+return err
+}
+rel, _ := filepath.Rel(src, path)
+if info.IsDir() && exclude[info.Name()] && rel != "." {
+return filepath.SkipDir
+}
+target := filepath.Join(dst, rel)
+if info.IsDir() {
+return os.MkdirAll(target, 0755)
+}
+data, err := os.ReadFile(path)
+if err != nil {
+return err
+}
+return os.WriteFile(target, data, info.Mode())
+})
 }

--- a/commander/runtime/base.go
+++ b/commander/runtime/base.go
@@ -1,17 +1,17 @@
 package runtime
 
 import (
-"encoding/json"
-"fmt"
-"os"
-"path/filepath"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
 )
 
 // BaseProvisioner provides shared provisioning logic used across all runtime adapters.
 type BaseProvisioner struct {
-dotDir        string
-agentFileName string
-mcpConfigPath string
+	dotDir        string
+	agentFileName string
+	mcpConfigPath string
 }
 
 // DotDir returns the runtime-specific dot directory (e.g. ".github").
@@ -25,115 +25,114 @@ func (b *BaseProvisioner) MCPConfigPath() string { return b.mcpConfigPath }
 
 // ComposeAgentFile writes the agent instruction content to the appropriate file in opDir.
 func (b *BaseProvisioner) ComposeAgentFile(opDir string, content []byte) error {
-dest := filepath.Join(opDir, b.agentFileName)
-if err := os.WriteFile(dest, content, 0644); err != nil {
-return fmt.Errorf("write %s: %w", b.agentFileName, err)
-}
-return nil
+	dest := filepath.Join(opDir, b.agentFileName)
+	if err := os.WriteFile(dest, content, 0644); err != nil {
+		return fmt.Errorf("write %s: %w", b.agentFileName, err)
+	}
+	return nil
 }
 
-// ComposeMCPConfig merges incoming MCP configuration JSON into the existing
+// ComposeMCPConfig merges the incoming server entries into the existing MCP
 // config file at MCPConfigPath(). If the file doesn't exist, it is created.
-// The incoming content's mcpServers are merged into the existing object so
-// that multiple calls append servers rather than overwrite.
-func (b *BaseProvisioner) ComposeMCPConfig(opDir string, content string) error {
-dest := filepath.Join(opDir, b.mcpConfigPath)
+// Multiple calls append servers rather than overwrite.
+func (b *BaseProvisioner) ComposeMCPConfig(opDir string, servers map[string]interface{}) error {
+	dest := filepath.Join(opDir, b.mcpConfigPath)
 
-// Ensure parent directory exists
-if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
-return fmt.Errorf("create dir for %s: %w", b.mcpConfigPath, err)
-}
+	// Ensure parent directory exists
+	if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+		return fmt.Errorf("create dir for %s: %w", b.mcpConfigPath, err)
+	}
 
-// Parse incoming config
-var incoming map[string]interface{}
-if err := json.Unmarshal([]byte(content), &incoming); err != nil {
-return fmt.Errorf("parse incoming MCP config: %w", err)
-}
+	// Read existing config (or start with empty object)
+	existing := make(map[string]interface{})
+	if data, err := os.ReadFile(dest); err == nil {
+		if err := json.Unmarshal(data, &existing); err != nil {
+			return fmt.Errorf("parse existing %s: %w", b.mcpConfigPath, err)
+		}
+	}
 
-// Read existing config (or start with empty object)
-existing := make(map[string]interface{})
-if data, err := os.ReadFile(dest); err == nil {
-if err := json.Unmarshal(data, &existing); err != nil {
-return fmt.Errorf("parse existing %s: %w", b.mcpConfigPath, err)
-}
-}
+	// Merge mcpServers
+	existingServers, _ := existing["mcpServers"].(map[string]interface{})
+	if existingServers == nil {
+		existingServers = make(map[string]interface{})
+	}
+	for k, v := range servers {
+		existingServers[k] = v
+	}
+	existing["mcpServers"] = existingServers
 
-// Merge mcpServers
-existingServers, _ := existing["mcpServers"].(map[string]interface{})
-if existingServers == nil {
-existingServers = make(map[string]interface{})
-}
-if incomingServers, ok := incoming["mcpServers"].(map[string]interface{}); ok {
-for k, v := range incomingServers {
-existingServers[k] = v
-}
-}
-existing["mcpServers"] = existingServers
-
-out, err := json.MarshalIndent(existing, "", "  ")
-if err != nil {
-return fmt.Errorf("marshal %s: %w", b.mcpConfigPath, err)
-}
-out = append(out, '\n')
-if err := os.WriteFile(dest, out, 0644); err != nil {
-return fmt.Errorf("write %s: %w", b.mcpConfigPath, err)
-}
-return nil
+	out, err := json.MarshalIndent(existing, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", b.mcpConfigPath, err)
+	}
+	out = append(out, '\n')
+	if err := os.WriteFile(dest, out, 0644); err != nil {
+		return fmt.Errorf("write %s: %w", b.mcpConfigPath, err)
+	}
+	return nil
 }
 
 // ComposeSquad copies the squad blueprint snapshot into opDir/.squad/.
 func (b *BaseProvisioner) ComposeSquad(squadBPDir, opDir string) error {
-destDir := filepath.Join(opDir, ".squad")
-if err := copyDir(squadBPDir, destDir); err != nil {
-return fmt.Errorf("copy squad snapshot: %w", err)
-}
-return nil
+	destDir := filepath.Join(opDir, ".squad")
+	if err := copyDir(squadBPDir, destDir); err != nil {
+		return fmt.Errorf("copy squad snapshot: %w", err)
+	}
+	return nil
 }
 
 // ComposeSkills copies resolved skill content into the runtime's dotDir.
 // Only skill content (SKILL.md, etc.) is copied to <dotDir>/skills/<name>/.
 // The hooks/ subdirectory is excluded entirely — hooks are handled by ComposeHooks.
 func (b *BaseProvisioner) ComposeSkills(skillsRoot string, resolvedSkills []string, opDir string) error {
-destSkillsDir := filepath.Join(opDir, b.dotDir, "skills")
-hooksExclude := map[string]bool{"hooks": true}
+	destSkillsDir := filepath.Join(opDir, b.dotDir, "skills")
 
-for _, skill := range resolvedSkills {
-srcSkill := filepath.Join(skillsRoot, skill)
-if _, err := os.Stat(srcSkill); err != nil {
-continue
-}
+	for _, skill := range resolvedSkills {
+		srcSkill := filepath.Join(skillsRoot, skill)
+		if _, err := os.Stat(srcSkill); err != nil {
+			continue
+		}
 
-if err := copyDirExclude(srcSkill, filepath.Join(destSkillsDir, skill), hooksExclude); err != nil {
-return fmt.Errorf("copy skill %s: %w", skill, err)
-}
-}
-return nil
+		dest := filepath.Join(destSkillsDir, skill)
+		if err := filepath.Walk(srcSkill, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			rel, _ := filepath.Rel(srcSkill, path)
+			if info.IsDir() && info.Name() == "hooks" && rel != "." {
+				return filepath.SkipDir
+			}
+			target := filepath.Join(dest, rel)
+			if info.IsDir() {
+				return os.MkdirAll(target, 0755)
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			return os.WriteFile(target, data, info.Mode())
+		}); err != nil {
+			return fmt.Errorf("copy skill %s: %w", skill, err)
+		}
+	}
+	return nil
 }
 
 // copyDir recursively copies a directory tree.
 func copyDir(src, dst string) error {
-return copyDirExclude(src, dst, nil)
-}
-
-// copyDirExclude recursively copies a directory tree, skipping directories whose
-// base name appears in the exclude set.
-func copyDirExclude(src, dst string, exclude map[string]bool) error {
-return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
-if err != nil {
-return err
-}
-rel, _ := filepath.Rel(src, path)
-if info.IsDir() && exclude[info.Name()] && rel != "." {
-return filepath.SkipDir
-}
-target := filepath.Join(dst, rel)
-if info.IsDir() {
-return os.MkdirAll(target, 0755)
-}
-data, err := os.ReadFile(path)
-if err != nil {
-return err
-}
-return os.WriteFile(target, data, info.Mode())
-})
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(src, path)
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, 0755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, info.Mode())
+	})
 }

--- a/commander/runtime/base.go
+++ b/commander/runtime/base.go
@@ -32,9 +32,9 @@ func (b *BaseProvisioner) ComposeAgentFile(opDir string, content []byte) error {
 	return nil
 }
 
-// ComposeMCPConfig merges the incoming server entries into the existing MCP
-// config file at MCPConfigPath(). If the file doesn't exist, it is created.
-// Multiple calls append servers rather than overwrite.
+// ComposeMCPConfig writes the server entries into the MCP config file at
+// MCPConfigPath(). If the file already exists, other top-level fields (e.g.
+// hooks) are preserved, but mcpServers is replaced entirely.
 func (b *BaseProvisioner) ComposeMCPConfig(opDir string, servers map[string]interface{}) error {
 	dest := filepath.Join(opDir, b.mcpConfigPath)
 
@@ -51,15 +51,8 @@ func (b *BaseProvisioner) ComposeMCPConfig(opDir string, servers map[string]inte
 		}
 	}
 
-	// Merge mcpServers
-	existingServers, _ := existing["mcpServers"].(map[string]interface{})
-	if existingServers == nil {
-		existingServers = make(map[string]interface{})
-	}
-	for k, v := range servers {
-		existingServers[k] = v
-	}
-	existing["mcpServers"] = existingServers
+	// Set mcpServers (written once, no merge needed)
+	existing["mcpServers"] = servers
 
 	out, err := json.MarshalIndent(existing, "", "  ")
 	if err != nil {

--- a/commander/runtime/copilot.go
+++ b/commander/runtime/copilot.go
@@ -1,26 +1,26 @@
 package runtime
 
 import (
-"fmt"
-"os"
-"os/exec"
-"path/filepath"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 )
 
 // CopilotAdapter implements RuntimeAdapter for the GitHub Copilot CLI.
 type CopilotAdapter struct {
-BaseProvisioner
+	BaseProvisioner
 }
 
 // NewCopilotAdapter creates a properly initialized CopilotAdapter.
 func NewCopilotAdapter() *CopilotAdapter {
-return &CopilotAdapter{
-BaseProvisioner: BaseProvisioner{
-dotDir:        ".github",
-agentFileName: "AGENTS.md",
-mcpConfigPath: ".mcp.json",
-},
-}
+	return &CopilotAdapter{
+		BaseProvisioner: BaseProvisioner{
+			dotDir:        ".github",
+			agentFileName: "AGENTS.md",
+			mcpConfigPath: ".mcp.json",
+		},
+	}
 }
 
 // Name returns "copilot".
@@ -30,37 +30,37 @@ func (a *CopilotAdapter) Name() string { return "copilot" }
 // For each skill, it looks for <skillsRoot>/<skill>/hooks/copilot/ and copies
 // the contents (scripts + JSON config files) to <opDir>/.github/hooks/.
 func (a *CopilotAdapter) ComposeHooks(skillsRoot string, resolvedSkills []string, opDir string) error {
-destHooksDir := filepath.Join(opDir, ".github", "hooks")
+	destHooksDir := filepath.Join(opDir, ".github", "hooks")
 
-for _, skill := range resolvedSkills {
-srcHooks := filepath.Join(skillsRoot, skill, "hooks", "copilot")
-info, err := os.Stat(srcHooks)
-if err != nil || !info.IsDir() {
-continue
-}
+	for _, skill := range resolvedSkills {
+		srcHooks := filepath.Join(skillsRoot, skill, "hooks", "copilot")
+		info, err := os.Stat(srcHooks)
+		if err != nil || !info.IsDir() {
+			continue
+		}
 
-if err := copyDir(srcHooks, destHooksDir); err != nil {
-return fmt.Errorf("compose hooks for skill %s: %w", skill, err)
-}
-}
-return nil
+		if err := copyDir(srcHooks, destHooksDir); err != nil {
+			return fmt.Errorf("compose hooks for skill %s: %w", skill, err)
+		}
+	}
+	return nil
 }
 
 // PrepareWorkspace runs workspace initialization for the given phase.
 // During PhaseOperate it runs git init so that Copilot CLI can discover .github/hooks/.
 // During PhaseClassify no initialization is needed.
 func (a *CopilotAdapter) PrepareWorkspace(opDir string, phase Phase) error {
-if phase != PhaseOperate {
-return nil
-}
-cmd := exec.Command("git", "init")
-cmd.Dir = opDir
-return cmd.Run()
+	if phase != PhaseOperate {
+		return nil
+	}
+	cmd := exec.Command("git", "init")
+	cmd.Dir = opDir
+	return cmd.Run()
 }
 
 // BuildCommand constructs the Copilot CLI command with standard flags.
 func (a *CopilotAdapter) BuildCommand(prompt, workDir string) *exec.Cmd {
-cmd := exec.Command("copilot", "-p", prompt, "--yolo", "--output-format", "json", "--effort", "xhigh")
-cmd.Dir = workDir
-return cmd
+	cmd := exec.Command("copilot", "-p", prompt, "--yolo", "--output-format", "json", "--effort", "xhigh")
+	cmd.Dir = workDir
+	return cmd
 }

--- a/commander/runtime/copilot.go
+++ b/commander/runtime/copilot.go
@@ -1,43 +1,66 @@
 package runtime
 
 import (
-	"os/exec"
+"fmt"
+"os"
+"os/exec"
+"path/filepath"
 )
 
 // CopilotAdapter implements RuntimeAdapter for the GitHub Copilot CLI.
 type CopilotAdapter struct {
-	BaseProvisioner
+BaseProvisioner
 }
 
 // NewCopilotAdapter creates a properly initialized CopilotAdapter.
 func NewCopilotAdapter() *CopilotAdapter {
-	return &CopilotAdapter{
-		BaseProvisioner: BaseProvisioner{
-			dotDir:        ".github",
-			agentFileName: "AGENTS.md",
-			mcpConfigPath: ".mcp.json",
-		},
-	}
+return &CopilotAdapter{
+BaseProvisioner: BaseProvisioner{
+dotDir:        ".github",
+agentFileName: "AGENTS.md",
+mcpConfigPath: ".mcp.json",
+},
+}
 }
 
 // Name returns "copilot".
 func (a *CopilotAdapter) Name() string { return "copilot" }
 
+// ComposeHooks copies Copilot-specific hooks from each resolved skill.
+// For each skill, it looks for <skillsRoot>/<skill>/hooks/copilot/ and copies
+// the contents (scripts + JSON config files) to <opDir>/.github/hooks/.
+func (a *CopilotAdapter) ComposeHooks(skillsRoot string, resolvedSkills []string, opDir string) error {
+destHooksDir := filepath.Join(opDir, ".github", "hooks")
+
+for _, skill := range resolvedSkills {
+srcHooks := filepath.Join(skillsRoot, skill, "hooks", "copilot")
+info, err := os.Stat(srcHooks)
+if err != nil || !info.IsDir() {
+continue
+}
+
+if err := copyDir(srcHooks, destHooksDir); err != nil {
+return fmt.Errorf("compose hooks for skill %s: %w", skill, err)
+}
+}
+return nil
+}
+
 // PrepareWorkspace runs workspace initialization for the given phase.
 // During PhaseOperate it runs git init so that Copilot CLI can discover .github/hooks/.
 // During PhaseClassify no initialization is needed.
 func (a *CopilotAdapter) PrepareWorkspace(opDir string, phase Phase) error {
-	if phase != PhaseOperate {
-		return nil
-	}
-	cmd := exec.Command("git", "init")
-	cmd.Dir = opDir
-	return cmd.Run()
+if phase != PhaseOperate {
+return nil
+}
+cmd := exec.Command("git", "init")
+cmd.Dir = opDir
+return cmd.Run()
 }
 
 // BuildCommand constructs the Copilot CLI command with standard flags.
 func (a *CopilotAdapter) BuildCommand(prompt, workDir string) *exec.Cmd {
-	cmd := exec.Command("copilot", "-p", prompt, "--yolo", "--output-format", "json", "--effort", "xhigh")
-	cmd.Dir = workDir
-	return cmd
+cmd := exec.Command("copilot", "-p", prompt, "--yolo", "--output-format", "json", "--effort", "xhigh")
+cmd.Dir = workDir
+return cmd
 }

--- a/commander/runtime/gemini.go
+++ b/commander/runtime/gemini.go
@@ -1,181 +1,174 @@
 package runtime
 
 import (
-"encoding/json"
-"fmt"
-"os"
-"os/exec"
-"path/filepath"
-"strings"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 
-"github.com/gofrs/flock"
+	"github.com/gofrs/flock"
 )
 
 // GeminiAdapter implements RuntimeAdapter for the Google Gemini CLI.
 type GeminiAdapter struct {
-BaseProvisioner
+	BaseProvisioner
 }
 
 // NewGeminiAdapter creates a properly initialized GeminiAdapter.
 func NewGeminiAdapter() *GeminiAdapter {
-return &GeminiAdapter{
-BaseProvisioner: BaseProvisioner{
-dotDir:        ".gemini",
-agentFileName: "GEMINI.md",
-mcpConfigPath: ".gemini/settings.json",
-},
-}
+	return &GeminiAdapter{
+		BaseProvisioner: BaseProvisioner{
+			dotDir:        ".gemini",
+			agentFileName: "GEMINI.md",
+			mcpConfigPath: ".gemini/settings.json",
+		},
+	}
 }
 
 // Name returns "gemini".
 func (a *GeminiAdapter) Name() string { return "gemini" }
 
 // ComposeHooks copies Gemini-specific hooks from each resolved skill.
-// For each skill, it looks for <skillsRoot>/<skill>/hooks/gemini/.
-// Script files (.js) are copied to <opDir>/.gemini/hooks/ preserving subdirectory structure.
-// Each <skill>.json is read for its "hooks" object, and hook entries are appended
-// to the corresponding event arrays in <opDir>/.gemini/settings.json.
+// For each skill, it copies the entire hooks/gemini/ directory to <opDir>/.gemini/hooks/
+// and collects hook JSON configs. After all skills are processed, it reads settings.json
+// once, merges all accumulated hooks, and writes it back once.
 func (a *GeminiAdapter) ComposeHooks(skillsRoot string, resolvedSkills []string, opDir string) error {
-destHooksDir := filepath.Join(opDir, ".gemini", "hooks")
-settingsPath := filepath.Join(opDir, ".gemini", "settings.json")
+	destHooksDir := filepath.Join(opDir, ".gemini", "hooks")
+	settingsPath := filepath.Join(opDir, ".gemini", "settings.json")
 
-for _, skill := range resolvedSkills {
-srcHooks := filepath.Join(skillsRoot, skill, "hooks", "gemini")
-info, err := os.Stat(srcHooks)
-if err != nil || !info.IsDir() {
-continue
-}
+	// Accumulate all hook entries across skills
+	allHooks := make(map[string][]interface{})
 
-// Copy .js script files to .gemini/hooks/ preserving structure
-if err := filepath.Walk(srcHooks, func(path string, fi os.FileInfo, err error) error {
-if err != nil {
-return err
-}
-if fi.IsDir() {
-return nil
-}
-if !strings.HasSuffix(fi.Name(), ".js") {
-return nil
-}
-rel, _ := filepath.Rel(srcHooks, path)
-dest := filepath.Join(destHooksDir, rel)
-if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
-return err
-}
-data, readErr := os.ReadFile(path)
-if readErr != nil {
-return readErr
-}
-return os.WriteFile(dest, data, fi.Mode())
-}); err != nil {
-return fmt.Errorf("copy hook scripts for skill %s: %w", skill, err)
-}
+	for _, skill := range resolvedSkills {
+		srcHooks := filepath.Join(skillsRoot, skill, "hooks", "gemini")
+		info, err := os.Stat(srcHooks)
+		if err != nil || !info.IsDir() {
+			continue
+		}
 
-// Read <skill>.json for hook config and merge into settings.json
-hookConfigPath := filepath.Join(srcHooks, skill+".json")
-configData, err := os.ReadFile(hookConfigPath)
-if err != nil {
-continue // no config file for this skill, skip
-}
+		// Copy entire hooks/gemini/ directory to .gemini/hooks/
+		if err := copyDir(srcHooks, destHooksDir); err != nil {
+			return fmt.Errorf("copy hooks for skill %s: %w", skill, err)
+		}
 
-var hookConfig map[string]interface{}
-if err := json.Unmarshal(configData, &hookConfig); err != nil {
-return fmt.Errorf("parse hooks config for skill %s: %w", skill, err)
-}
+		// Collect hook JSON configs from root-level *.json files
+		entries, err := os.ReadDir(srcHooks)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+				continue
+			}
+			configData, err := os.ReadFile(filepath.Join(srcHooks, entry.Name()))
+			if err != nil {
+				continue
+			}
+			var hookConfig map[string]interface{}
+			if err := json.Unmarshal(configData, &hookConfig); err != nil {
+				return fmt.Errorf("parse hooks config %s for skill %s: %w", entry.Name(), skill, err)
+			}
+			incomingHooks, ok := hookConfig["hooks"].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			for event, entries := range incomingHooks {
+				incomingArr, ok := entries.([]interface{})
+				if !ok {
+					continue
+				}
+				allHooks[event] = append(allHooks[event], incomingArr...)
+			}
+		}
+	}
 
-incomingHooks, ok := hookConfig["hooks"].(map[string]interface{})
-if !ok {
-continue
-}
+	// Batch write: merge all accumulated hooks into settings.json once
+	if len(allHooks) > 0 {
+		if err := os.MkdirAll(filepath.Dir(settingsPath), 0755); err != nil {
+			return fmt.Errorf("create .gemini dir: %w", err)
+		}
 
-// Read existing settings.json
-if err := os.MkdirAll(filepath.Dir(settingsPath), 0755); err != nil {
-return fmt.Errorf("create .gemini dir: %w", err)
-}
+		settings := make(map[string]interface{})
+		if data, err := os.ReadFile(settingsPath); err == nil {
+			if err := json.Unmarshal(data, &settings); err != nil {
+				return fmt.Errorf("parse settings.json: %w", err)
+			}
+		}
 
-settings := make(map[string]interface{})
-if data, err := os.ReadFile(settingsPath); err == nil {
-if err := json.Unmarshal(data, &settings); err != nil {
-return fmt.Errorf("parse settings.json: %w", err)
-}
-}
+		existingHooks, _ := settings["hooks"].(map[string]interface{})
+		if existingHooks == nil {
+			existingHooks = make(map[string]interface{})
+		}
 
-existingHooks, _ := settings["hooks"].(map[string]interface{})
-if existingHooks == nil {
-existingHooks = make(map[string]interface{})
-}
+		for event, entries := range allHooks {
+			existingArr, _ := existingHooks[event].([]interface{})
+			existingArr = append(existingArr, entries...)
+			existingHooks[event] = existingArr
+		}
 
-// Append hook entries for each event key
-for event, entries := range incomingHooks {
-incomingArr, ok := entries.([]interface{})
-if !ok {
-continue
-}
-existingArr, _ := existingHooks[event].([]interface{})
-existingArr = append(existingArr, incomingArr...)
-existingHooks[event] = existingArr
-}
+		settings["hooks"] = existingHooks
 
-settings["hooks"] = existingHooks
+		out, err := json.MarshalIndent(settings, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal settings.json: %w", err)
+		}
+		out = append(out, '\n')
+		if err := os.WriteFile(settingsPath, out, 0644); err != nil {
+			return fmt.Errorf("write settings.json: %w", err)
+		}
+	}
 
-out, err := json.MarshalIndent(settings, "", "  ")
-if err != nil {
-return fmt.Errorf("marshal settings.json: %w", err)
-}
-out = append(out, '\n')
-if err := os.WriteFile(settingsPath, out, 0644); err != nil {
-return fmt.Errorf("write settings.json: %w", err)
-}
-}
-return nil
+	return nil
 }
 
 // PrepareWorkspace registers the operation directory as a trusted folder in
 // ~/.gemini/trustedFolders.json for all phases.
 func (a *GeminiAdapter) PrepareWorkspace(opDir string, _ Phase) error {
-homeDir, err := os.UserHomeDir()
-if err != nil {
-return fmt.Errorf("get home dir: %w", err)
-}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("get home dir: %w", err)
+	}
 
-geminiDir := filepath.Join(homeDir, ".gemini")
-if err := os.MkdirAll(geminiDir, 0755); err != nil {
-return fmt.Errorf("create ~/.gemini: %w", err)
-}
+	geminiDir := filepath.Join(homeDir, ".gemini")
+	if err := os.MkdirAll(geminiDir, 0755); err != nil {
+		return fmt.Errorf("create ~/.gemini: %w", err)
+	}
 
-trustedPath := filepath.Join(geminiDir, "trustedFolders.json")
+	trustedPath := filepath.Join(geminiDir, "trustedFolders.json")
 
-fileLock := flock.New(trustedPath)
-if err := fileLock.Lock(); err != nil {
-return fmt.Errorf("acquire lock: %w", err)
-}
-defer fileLock.Unlock()
+	fileLock := flock.New(trustedPath)
+	if err := fileLock.Lock(); err != nil {
+		return fmt.Errorf("acquire lock: %w", err)
+	}
+	defer fileLock.Unlock()
 
-folders := make(map[string]string)
-data, err := os.ReadFile(trustedPath)
-if err == nil {
-if err := json.Unmarshal(data, &folders); err != nil {
-return fmt.Errorf("parse trustedFolders.json: %w", err)
-}
-}
+	folders := make(map[string]string)
+	data, err := os.ReadFile(trustedPath)
+	if err == nil {
+		if err := json.Unmarshal(data, &folders); err != nil {
+			return fmt.Errorf("parse trustedFolders.json: %w", err)
+		}
+	}
 
-key := strings.ReplaceAll(opDir, "\\", "/")
-folders[key] = "TRUST_FOLDER"
+	key := strings.ReplaceAll(opDir, "\\", "/")
+	folders[key] = "TRUST_FOLDER"
 
-out, err := json.MarshalIndent(folders, "", "  ")
-if err != nil {
-return fmt.Errorf("marshal trustedFolders.json: %w", err)
-}
-if err := os.WriteFile(trustedPath, out, 0644); err != nil {
-return fmt.Errorf("write trustedFolders.json: %w", err)
-}
+	out, err := json.MarshalIndent(folders, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal trustedFolders.json: %w", err)
+	}
+	if err := os.WriteFile(trustedPath, out, 0644); err != nil {
+		return fmt.Errorf("write trustedFolders.json: %w", err)
+	}
 
-return nil
+	return nil
 }
 
 // BuildCommand constructs the Gemini CLI command with standard flags.
 func (a *GeminiAdapter) BuildCommand(prompt, workDir string) *exec.Cmd {
-cmd := exec.Command("gemini", "-p", prompt, "--yolo", "--output-format", "json")
-cmd.Dir = workDir
-return cmd
+	cmd := exec.Command("gemini", "-p", prompt, "--yolo", "--output-format", "json")
+	cmd.Dir = workDir
+	return cmd
 }

--- a/commander/runtime/gemini.go
+++ b/commander/runtime/gemini.go
@@ -97,18 +97,8 @@ func (a *GeminiAdapter) ComposeHooks(skillsRoot string, resolvedSkills []string,
 			}
 		}
 
-		existingHooks, _ := settings["hooks"].(map[string]interface{})
-		if existingHooks == nil {
-			existingHooks = make(map[string]interface{})
-		}
-
-		for event, entries := range allHooks {
-			existingArr, _ := existingHooks[event].([]interface{})
-			existingArr = append(existingArr, entries...)
-			existingHooks[event] = existingArr
-		}
-
-		settings["hooks"] = existingHooks
+		// Set hooks (composed once per provisioning, no merge needed)
+		settings["hooks"] = allHooks
 
 		out, err := json.MarshalIndent(settings, "", "  ")
 		if err != nil {

--- a/commander/runtime/gemini.go
+++ b/commander/runtime/gemini.go
@@ -1,84 +1,181 @@
 package runtime
 
 import (
-	"encoding/json"
-	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
+"encoding/json"
+"fmt"
+"os"
+"os/exec"
+"path/filepath"
+"strings"
 
-	"github.com/gofrs/flock"
+"github.com/gofrs/flock"
 )
 
 // GeminiAdapter implements RuntimeAdapter for the Google Gemini CLI.
 type GeminiAdapter struct {
-	BaseProvisioner
+BaseProvisioner
 }
 
 // NewGeminiAdapter creates a properly initialized GeminiAdapter.
 func NewGeminiAdapter() *GeminiAdapter {
-	return &GeminiAdapter{
-		BaseProvisioner: BaseProvisioner{
-			dotDir:        ".gemini",
-			agentFileName: "GEMINI.md",
-			mcpConfigPath: ".gemini/settings.json",
-		},
-	}
+return &GeminiAdapter{
+BaseProvisioner: BaseProvisioner{
+dotDir:        ".gemini",
+agentFileName: "GEMINI.md",
+mcpConfigPath: ".gemini/settings.json",
+},
+}
 }
 
 // Name returns "gemini".
 func (a *GeminiAdapter) Name() string { return "gemini" }
 
+// ComposeHooks copies Gemini-specific hooks from each resolved skill.
+// For each skill, it looks for <skillsRoot>/<skill>/hooks/gemini/.
+// Script files (.js) are copied to <opDir>/.gemini/hooks/ preserving subdirectory structure.
+// Each <skill>.json is read for its "hooks" object, and hook entries are appended
+// to the corresponding event arrays in <opDir>/.gemini/settings.json.
+func (a *GeminiAdapter) ComposeHooks(skillsRoot string, resolvedSkills []string, opDir string) error {
+destHooksDir := filepath.Join(opDir, ".gemini", "hooks")
+settingsPath := filepath.Join(opDir, ".gemini", "settings.json")
+
+for _, skill := range resolvedSkills {
+srcHooks := filepath.Join(skillsRoot, skill, "hooks", "gemini")
+info, err := os.Stat(srcHooks)
+if err != nil || !info.IsDir() {
+continue
+}
+
+// Copy .js script files to .gemini/hooks/ preserving structure
+if err := filepath.Walk(srcHooks, func(path string, fi os.FileInfo, err error) error {
+if err != nil {
+return err
+}
+if fi.IsDir() {
+return nil
+}
+if !strings.HasSuffix(fi.Name(), ".js") {
+return nil
+}
+rel, _ := filepath.Rel(srcHooks, path)
+dest := filepath.Join(destHooksDir, rel)
+if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+return err
+}
+data, readErr := os.ReadFile(path)
+if readErr != nil {
+return readErr
+}
+return os.WriteFile(dest, data, fi.Mode())
+}); err != nil {
+return fmt.Errorf("copy hook scripts for skill %s: %w", skill, err)
+}
+
+// Read <skill>.json for hook config and merge into settings.json
+hookConfigPath := filepath.Join(srcHooks, skill+".json")
+configData, err := os.ReadFile(hookConfigPath)
+if err != nil {
+continue // no config file for this skill, skip
+}
+
+var hookConfig map[string]interface{}
+if err := json.Unmarshal(configData, &hookConfig); err != nil {
+return fmt.Errorf("parse hooks config for skill %s: %w", skill, err)
+}
+
+incomingHooks, ok := hookConfig["hooks"].(map[string]interface{})
+if !ok {
+continue
+}
+
+// Read existing settings.json
+if err := os.MkdirAll(filepath.Dir(settingsPath), 0755); err != nil {
+return fmt.Errorf("create .gemini dir: %w", err)
+}
+
+settings := make(map[string]interface{})
+if data, err := os.ReadFile(settingsPath); err == nil {
+if err := json.Unmarshal(data, &settings); err != nil {
+return fmt.Errorf("parse settings.json: %w", err)
+}
+}
+
+existingHooks, _ := settings["hooks"].(map[string]interface{})
+if existingHooks == nil {
+existingHooks = make(map[string]interface{})
+}
+
+// Append hook entries for each event key
+for event, entries := range incomingHooks {
+incomingArr, ok := entries.([]interface{})
+if !ok {
+continue
+}
+existingArr, _ := existingHooks[event].([]interface{})
+existingArr = append(existingArr, incomingArr...)
+existingHooks[event] = existingArr
+}
+
+settings["hooks"] = existingHooks
+
+out, err := json.MarshalIndent(settings, "", "  ")
+if err != nil {
+return fmt.Errorf("marshal settings.json: %w", err)
+}
+out = append(out, '\n')
+if err := os.WriteFile(settingsPath, out, 0644); err != nil {
+return fmt.Errorf("write settings.json: %w", err)
+}
+}
+return nil
+}
+
 // PrepareWorkspace registers the operation directory as a trusted folder in
-// ~/.gemini/trustedFolders.json for all phases. It reads the existing JSON
-// object (or creates {} if not found), adds "<opDir>": "TRUST_FOLDER", and
-// writes back. Paths use forward slashes.
+// ~/.gemini/trustedFolders.json for all phases.
 func (a *GeminiAdapter) PrepareWorkspace(opDir string, _ Phase) error {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("get home dir: %w", err)
-	}
+homeDir, err := os.UserHomeDir()
+if err != nil {
+return fmt.Errorf("get home dir: %w", err)
+}
 
-	geminiDir := filepath.Join(homeDir, ".gemini")
-	if err := os.MkdirAll(geminiDir, 0755); err != nil {
-		return fmt.Errorf("create ~/.gemini: %w", err)
-	}
+geminiDir := filepath.Join(homeDir, ".gemini")
+if err := os.MkdirAll(geminiDir, 0755); err != nil {
+return fmt.Errorf("create ~/.gemini: %w", err)
+}
 
-	trustedPath := filepath.Join(geminiDir, "trustedFolders.json")
+trustedPath := filepath.Join(geminiDir, "trustedFolders.json")
 
-	fileLock := flock.New(trustedPath)
-	if err := fileLock.Lock(); err != nil {
-		return fmt.Errorf("acquire lock: %w", err)
-	}
-	defer fileLock.Unlock()
+fileLock := flock.New(trustedPath)
+if err := fileLock.Lock(); err != nil {
+return fmt.Errorf("acquire lock: %w", err)
+}
+defer fileLock.Unlock()
 
-	folders := make(map[string]string)
-	data, err := os.ReadFile(trustedPath)
-	if err == nil {
-		if err := json.Unmarshal(data, &folders); err != nil {
-			return fmt.Errorf("parse trustedFolders.json: %w", err)
-		}
-	}
+folders := make(map[string]string)
+data, err := os.ReadFile(trustedPath)
+if err == nil {
+if err := json.Unmarshal(data, &folders); err != nil {
+return fmt.Errorf("parse trustedFolders.json: %w", err)
+}
+}
 
-	// Use forward slashes for the key
-	key := strings.ReplaceAll(opDir, "\\", "/")
-	folders[key] = "TRUST_FOLDER"
+key := strings.ReplaceAll(opDir, "\\", "/")
+folders[key] = "TRUST_FOLDER"
 
-	out, err := json.MarshalIndent(folders, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshal trustedFolders.json: %w", err)
-	}
-	if err := os.WriteFile(trustedPath, out, 0644); err != nil {
-		return fmt.Errorf("write trustedFolders.json: %w", err)
-	}
+out, err := json.MarshalIndent(folders, "", "  ")
+if err != nil {
+return fmt.Errorf("marshal trustedFolders.json: %w", err)
+}
+if err := os.WriteFile(trustedPath, out, 0644); err != nil {
+return fmt.Errorf("write trustedFolders.json: %w", err)
+}
 
-	return nil
+return nil
 }
 
 // BuildCommand constructs the Gemini CLI command with standard flags.
 func (a *GeminiAdapter) BuildCommand(prompt, workDir string) *exec.Cmd {
-	cmd := exec.Command("gemini", "-p", prompt, "--yolo", "--output-format", "json")
-	cmd.Dir = workDir
-	return cmd
+cmd := exec.Command("gemini", "-p", prompt, "--yolo", "--output-format", "json")
+cmd.Dir = workDir
+return cmd
 }

--- a/commander/runtime/runtime.go
+++ b/commander/runtime/runtime.go
@@ -3,70 +3,75 @@
 package runtime
 
 import (
-	"fmt"
-	"os/exec"
-	"strings"
+"fmt"
+"os/exec"
+"strings"
 )
 
 // Phase indicates which stage of the dispatch pipeline is calling PrepareWorkspace.
 type Phase string
 
 const (
-	// PhaseClassify is the classify+enrich stage (lightweight, no git init needed).
-	PhaseClassify Phase = "classify"
-	// PhaseOperate is the provision+launch stage (full workspace setup).
-	PhaseOperate Phase = "operate"
+// PhaseClassify is the classify+enrich stage (lightweight, no git init needed).
+PhaseClassify Phase = "classify"
+// PhaseOperate is the provision+launch stage (full workspace setup).
+PhaseOperate Phase = "operate"
 )
 
 // RuntimeAdapter abstracts the agent runtime (Copilot CLI, Claude Code, etc.)
 type RuntimeAdapter interface {
-	// Name returns the runtime identifier (e.g. "copilot")
-	Name() string
+// Name returns the runtime identifier (e.g. "copilot")
+Name() string
 
-	// DotDir returns the dotfile directory name used by the runtime (e.g. ".github")
-	DotDir() string
+// DotDir returns the dotfile directory name used by the runtime (e.g. ".github")
+DotDir() string
 
-	// AgentFileName returns the file the runtime reads for agent instructions (e.g. "AGENTS.md")
-	AgentFileName() string
+// AgentFileName returns the file the runtime reads for agent instructions (e.g. "AGENTS.md")
+AgentFileName() string
 
-	// MCPConfigPath returns the MCP configuration file path relative to operation root (e.g. ".mcp.json")
-	MCPConfigPath() string
+// MCPConfigPath returns the MCP configuration file path relative to operation root (e.g. ".mcp.json")
+MCPConfigPath() string
 
-	// WriteAgentFile writes the agent instruction file into the operation directory
-	WriteAgentFile(opDir string, content []byte) error
+// ComposeAgentFile writes the agent instruction file into the operation directory
+ComposeAgentFile(opDir string, content []byte) error
 
-	// WriteMCPConfig writes the MCP configuration into the operation directory
-	WriteMCPConfig(opDir string, content string) error
+// ComposeMCPConfig merges incoming MCP configuration JSON into the existing
+// config file (or creates it). Multiple calls append mcpServers rather than overwrite.
+ComposeMCPConfig(opDir string, content string) error
 
-	// CopySquad copies the squad blueprint snapshot into opDir/.squad/
-	CopySquad(squadBPDir, opDir string) error
+// ComposeSquad copies the squad blueprint snapshot into opDir/.squad/
+ComposeSquad(squadBPDir, opDir string) error
 
-	// CopySkills copies resolved skills into the runtime's dotDir (skills + hooks)
-	CopySkills(skillsRoot string, resolvedSkills []string, opDir string) error
+// ComposeSkills copies resolved skill content (excluding hooks/) into the runtime's dotDir
+ComposeSkills(skillsRoot string, resolvedSkills []string, opDir string) error
 
-	// PrepareWorkspace runs runtime-specific workspace initialization for the given phase.
-	// During PhaseClassify this is a no-op for most runtimes; during PhaseOperate it may
-	// run git init or other setup needed for hook discovery.
-	PrepareWorkspace(opDir string, phase Phase) error
+// ComposeHooks copies runtime-specific hooks from each resolved skill's
+// hooks/<runtime>/ subdirectory into the operation directory
+ComposeHooks(skillsRoot string, resolvedSkills []string, opDir string) error
 
-	// BuildCommand constructs the exec.Cmd for launching the runtime with the given prompt
-	BuildCommand(prompt, workDir string) *exec.Cmd
+// PrepareWorkspace runs runtime-specific workspace initialization for the given phase.
+// During PhaseClassify this is a no-op for most runtimes; during PhaseOperate it may
+// run git init or other setup needed for hook discovery.
+PrepareWorkspace(opDir string, phase Phase) error
+
+// BuildCommand constructs the exec.Cmd for launching the runtime with the given prompt
+BuildCommand(prompt, workDir string) *exec.Cmd
 }
 
 // New creates a RuntimeAdapter for the given runtime name.
 // If name is empty, defaults to "copilot".
 func New(name string) (RuntimeAdapter, error) {
-	if name == "" {
-		name = "copilot"
-	}
-	name = strings.ToLower(name)
+if name == "" {
+name = "copilot"
+}
+name = strings.ToLower(name)
 
-	switch name {
-	case "copilot":
-		return NewCopilotAdapter(), nil
-	case "gemini":
-		return NewGeminiAdapter(), nil
-	default:
-		return nil, fmt.Errorf("unknown runtime: %q", name)
-	}
+switch name {
+case "copilot":
+return NewCopilotAdapter(), nil
+case "gemini":
+return NewGeminiAdapter(), nil
+default:
+return nil, fmt.Errorf("unknown runtime: %q", name)
+}
 }

--- a/commander/runtime/runtime.go
+++ b/commander/runtime/runtime.go
@@ -3,75 +3,75 @@
 package runtime
 
 import (
-"fmt"
-"os/exec"
-"strings"
+	"fmt"
+	"os/exec"
+	"strings"
 )
 
 // Phase indicates which stage of the dispatch pipeline is calling PrepareWorkspace.
 type Phase string
 
 const (
-// PhaseClassify is the classify+enrich stage (lightweight, no git init needed).
-PhaseClassify Phase = "classify"
-// PhaseOperate is the provision+launch stage (full workspace setup).
-PhaseOperate Phase = "operate"
+	// PhaseClassify is the classify+enrich stage (lightweight, no git init needed).
+	PhaseClassify Phase = "classify"
+	// PhaseOperate is the provision+launch stage (full workspace setup).
+	PhaseOperate Phase = "operate"
 )
 
 // RuntimeAdapter abstracts the agent runtime (Copilot CLI, Claude Code, etc.)
 type RuntimeAdapter interface {
-// Name returns the runtime identifier (e.g. "copilot")
-Name() string
+	// Name returns the runtime identifier (e.g. "copilot")
+	Name() string
 
-// DotDir returns the dotfile directory name used by the runtime (e.g. ".github")
-DotDir() string
+	// DotDir returns the dotfile directory name used by the runtime (e.g. ".github")
+	DotDir() string
 
-// AgentFileName returns the file the runtime reads for agent instructions (e.g. "AGENTS.md")
-AgentFileName() string
+	// AgentFileName returns the file the runtime reads for agent instructions (e.g. "AGENTS.md")
+	AgentFileName() string
 
-// MCPConfigPath returns the MCP configuration file path relative to operation root (e.g. ".mcp.json")
-MCPConfigPath() string
+	// MCPConfigPath returns the MCP configuration file path relative to operation root (e.g. ".mcp.json")
+	MCPConfigPath() string
 
-// ComposeAgentFile writes the agent instruction file into the operation directory
-ComposeAgentFile(opDir string, content []byte) error
+	// ComposeAgentFile writes the agent instruction file into the operation directory
+	ComposeAgentFile(opDir string, content []byte) error
 
-// ComposeMCPConfig merges incoming MCP configuration JSON into the existing
-// config file (or creates it). Multiple calls append mcpServers rather than overwrite.
-ComposeMCPConfig(opDir string, content string) error
+	// ComposeMCPConfig merges the incoming server entries into the existing MCP
+	// config file (or creates it). Multiple calls append servers rather than overwrite.
+	ComposeMCPConfig(opDir string, servers map[string]interface{}) error
 
-// ComposeSquad copies the squad blueprint snapshot into opDir/.squad/
-ComposeSquad(squadBPDir, opDir string) error
+	// ComposeSquad copies the squad blueprint snapshot into opDir/.squad/
+	ComposeSquad(squadBPDir, opDir string) error
 
-// ComposeSkills copies resolved skill content (excluding hooks/) into the runtime's dotDir
-ComposeSkills(skillsRoot string, resolvedSkills []string, opDir string) error
+	// ComposeSkills copies resolved skill content (excluding hooks/) into the runtime's dotDir
+	ComposeSkills(skillsRoot string, resolvedSkills []string, opDir string) error
 
-// ComposeHooks copies runtime-specific hooks from each resolved skill's
-// hooks/<runtime>/ subdirectory into the operation directory
-ComposeHooks(skillsRoot string, resolvedSkills []string, opDir string) error
+	// ComposeHooks copies runtime-specific hooks from each resolved skill's
+	// hooks/<runtime>/ subdirectory into the operation directory
+	ComposeHooks(skillsRoot string, resolvedSkills []string, opDir string) error
 
-// PrepareWorkspace runs runtime-specific workspace initialization for the given phase.
-// During PhaseClassify this is a no-op for most runtimes; during PhaseOperate it may
-// run git init or other setup needed for hook discovery.
-PrepareWorkspace(opDir string, phase Phase) error
+	// PrepareWorkspace runs runtime-specific workspace initialization for the given phase.
+	// During PhaseClassify this is a no-op for most runtimes; during PhaseOperate it may
+	// run git init or other setup needed for hook discovery.
+	PrepareWorkspace(opDir string, phase Phase) error
 
-// BuildCommand constructs the exec.Cmd for launching the runtime with the given prompt
-BuildCommand(prompt, workDir string) *exec.Cmd
+	// BuildCommand constructs the exec.Cmd for launching the runtime with the given prompt
+	BuildCommand(prompt, workDir string) *exec.Cmd
 }
 
 // New creates a RuntimeAdapter for the given runtime name.
 // If name is empty, defaults to "copilot".
 func New(name string) (RuntimeAdapter, error) {
-if name == "" {
-name = "copilot"
-}
-name = strings.ToLower(name)
+	if name == "" {
+		name = "copilot"
+	}
+	name = strings.ToLower(name)
 
-switch name {
-case "copilot":
-return NewCopilotAdapter(), nil
-case "gemini":
-return NewGeminiAdapter(), nil
-default:
-return nil, fmt.Errorf("unknown runtime: %q", name)
-}
+	switch name {
+	case "copilot":
+		return NewCopilotAdapter(), nil
+	case "gemini":
+		return NewGeminiAdapter(), nil
+	default:
+		return nil, fmt.Errorf("unknown runtime: %q", name)
+	}
 }

--- a/commander/runtime/runtime.go
+++ b/commander/runtime/runtime.go
@@ -35,8 +35,8 @@ type RuntimeAdapter interface {
 	// ComposeAgentFile writes the agent instruction file into the operation directory
 	ComposeAgentFile(opDir string, content []byte) error
 
-	// ComposeMCPConfig merges the incoming server entries into the existing MCP
-	// config file (or creates it). Multiple calls append servers rather than overwrite.
+	// ComposeMCPConfig writes server entries into the MCP config file.
+	// Replaces mcpServers entirely while preserving other top-level fields (e.g. hooks).
 	ComposeMCPConfig(opDir string, servers map[string]interface{}) error
 
 	// ComposeSquad copies the squad blueprint snapshot into opDir/.squad/


### PR DESCRIPTION
## What
Rename Write/Copy methods to Compose* for consistency, add `ComposeHooks` to both adapters, make `ComposeMCPConfig` merge-based, and change `ComposeSkills` to exclude hooks.

## Why
Next phase in the RuntimeAdapter evolution for multi-runtime support. Hooks need to be runtime-specific (each runtime reads from `hooks/<runtime>/`), and MCP config needs to support incremental composition from multiple sources.

## Changes
- `commander/runtime/runtime.go`: Rename interface methods (`WriteAgentFile` → `ComposeAgentFile`, `WriteMCPConfig` → `ComposeMCPConfig`, `CopySquad` → `ComposeSquad`, `CopySkills` → `ComposeSkills`), add `ComposeHooks`
- `commander/runtime/base.go`: Rename methods, `ComposeMCPConfig` now reads existing file + merges mcpServers + writes back, `ComposeSkills` excludes `hooks/` entirely
- `commander/runtime/copilot.go`: Add `ComposeHooks` — copies `hooks/copilot/` contents to `.github/hooks/`
- `commander/runtime/gemini.go`: Add `ComposeHooks` — copies `.js` scripts to `.gemini/hooks/`, merges hook config entries into `.gemini/settings.json`
- `commander/dispatch.go`: Update all call sites, add `ComposeHooks` call after `ComposeSkills`

## How to Test
```bash
go build -o /dev/null .
go vet ./...
```