### PR TITLE
fix: add --include-directories to Gemini CLI launch

### DIFF
--- a/commander/runtime/gemini.go
+++ b/commander/runtime/gemini.go
@@ -164,7 +164,7 @@ func (a *GeminiAdapter) PrepareWorkspace(opDir string, _ Phase) error {
 
 // BuildCommand constructs the Gemini CLI command with standard flags.
 func (a *GeminiAdapter) BuildCommand(prompt, workDir string) *exec.Cmd {
-	cmd := exec.Command("gemini", "-p", prompt, "--yolo", "--output-format", "stream-json")
+	cmd := exec.Command("gemini", "-p", prompt, "--yolo", "--output-format", "stream-json", "--include-directories", layout.Root())
 	cmd.Dir = workDir
 	return cmd
 }


### PR DESCRIPTION
trustedFolders alone is not sufficient — Gemini CLI also needs `--include-directories` pointing to `~/.swat` for blueprint access during classify.