### PR TITLE
fix: symlink swat to ~/.local/bin for reliable PATH discovery

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -140,27 +140,25 @@ install_blueprints() {
 
 
 post_install() {
-    # PATH check — auto-add if missing
+    # Symlink to ~/.local/bin (commonly in PATH on Linux/macOS)
+    local local_bin="$HOME/.local/bin"
+    mkdir -p "$local_bin"
+    ln -sf "$BIN_DIR/swat" "$local_bin/swat"
+    ok "Symlinked $local_bin/swat → $BIN_DIR/swat"
+
+    # Also add BIN_DIR to shell profiles as fallback
     if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then
         local line="export PATH=\"$BIN_DIR:\$PATH\""
-        local added=false
         for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
             if [[ -f "$rc" ]] && ! grep -qF "$BIN_DIR" "$rc" 2>/dev/null; then
                 echo "" >> "$rc"
                 echo "# Added by SWAT installer" >> "$rc"
                 echo "$line" >> "$rc"
-                added=true
                 ok "Added $BIN_DIR to PATH in $(basename "$rc")"
             fi
         done
-        if [[ "$added" == false ]]; then
-            info "Add to your shell profile:"
-            echo "  $line"
-            echo ""
-        fi
         export PATH="$BIN_DIR:$PATH"
     fi
-
 }
 
 # --- Cleanup ---


### PR DESCRIPTION
## Problem
swat binary installed to `~/.swat/bin/` is not discoverable by non-interactive processes (Go `exec.Command`, Copilot CLI sessions) because `~/.swat/bin` is not in the default PATH. Writing to `.bashrc` only helps interactive shells.

## Fix
Symlink `~/.local/bin/swat` → `~/.swat/bin/swat` during install. `~/.local/bin` is typically pre-configured in PATH on most Linux/macOS systems, making the binary discoverable by all processes.

Keeps the `.bashrc` fallback for systems where `~/.local/bin` is not in PATH.