### PR TITLE
docs: fix README accuracy and CI go-version (issue #62 findings #6, #7, #8, #14)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version-file: go.mod
 
       - name: Build binary
         env:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ irm https://raw.githubusercontent.com/LangSensei/swat/main/install.ps1 | iex
 
 This will:
 1. Download the latest release for your platform
-2. Install the SWAT binary to `~/.swat/bin/` with a symlink at `~/.local/bin/swat` (auto-added to PATH)
+2. Install the SWAT binary to `~/.swat/bin/` with a symlink at `~/.local/bin/swat` (Linux only; auto-added to PATH)
 3. Install framework blueprints to `~/.swat/blueprints/`
 
 ### OpenClaw Integration (Optional)
@@ -83,7 +83,7 @@ SWAT exposes 12 MCP tools. Configure your agent to connect:
 | `--version` | Print the installed version and exit |
 | `--mcp-only` | Start only the MCP server — skip the background commander loop |
 | `--runtime <name>` | Set the AI coding agent runtime (default: `copilot`) |
-| `--notify <backend>` | Set the notification backend (default: `desktop`) |
+| `--notify <target>` | Set the notification target: `desktop`, `openclaw` (default: `desktop`) |
 
 ## 🧠 Architecture
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ irm https://raw.githubusercontent.com/LangSensei/swat/main/install.ps1 | iex
 
 This will:
 1. Download the latest release for your platform
-2. Install the SWAT binary to `~/.local/bin/` (auto-added to PATH)
+2. Install the SWAT binary to `~/.swat/bin/` with a symlink at `~/.local/bin/swat` (auto-added to PATH)
 3. Install framework blueprints to `~/.swat/blueprints/`
 
 ### OpenClaw Integration (Optional)
@@ -39,7 +39,7 @@ Add `--purge` to also remove runtime data (operation history).
 
 ## 🎮 Usage
 
-SWAT exposes 10 MCP tools. Configure your agent to connect:
+SWAT exposes 12 MCP tools. Configure your agent to connect:
 
 ### MCP Configuration
 
@@ -73,12 +73,17 @@ SWAT exposes 10 MCP tools. Configure your agent to connect:
 - `swat_schedules` — List all schedules
 - `swat_schedule_delete` — Delete a schedule
 
+#### Notification
+- `swat_notify` — Send a notification to the user
+
 ### CLI Flags
 
 | Flag | Description |
 |------|-------------|
 | `--version` | Print the installed version and exit |
 | `--mcp-only` | Start only the MCP server — skip the background commander loop |
+| `--runtime <name>` | Set the AI coding agent runtime (default: `copilot`) |
+| `--notify <backend>` | Set the notification backend (default: `desktop`) |
 
 ## 🧠 Architecture
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ irm https://raw.githubusercontent.com/LangSensei/swat/main/install.ps1 | iex
 
 This will:
 1. Download the latest release for your platform
-2. Install the SWAT binary to `~/.swat/bin/` with a symlink at `~/.local/bin/swat` (Linux only; auto-added to PATH)
+2. Install the SWAT binary to `~/.swat/bin/` and add it to your PATH (Linux/macOS: appends to `.bashrc`/`.zshrc`; Windows: updates user PATH in the registry)
 3. Install framework blueprints to `~/.swat/blueprints/`
 
 ### OpenClaw Integration (Optional)


### PR DESCRIPTION
## What
Fix 4 documentation/CI findings from issue #62.

## Why
Issue #62 audit identified inaccuracies in README.md and a hardcoded Go version in CI.

## Changes
- **README.md**: Fix install path description (`~/.swat/bin/` with symlink at `~/.local/bin/swat`)
- **README.md**: Fix tool count from 10 → 12 MCP tools
- **README.md**: Add missing `swat_notify` tool documentation and `--runtime`/`--notify` CLI flags
- **.github/workflows/release.yml**: Change `go-version: '1.24'` to `go-version-file: go.mod`

## How to Test
1. Verify README tool count matches tools in `mcp/mcp.go` (12 tools)
2. Verify all CLI flags from `main.go` are documented in README
3. Verify `release.yml` references `go.mod` instead of hardcoded version

Fixes #62 (findings #6, #7, #8, #14)