### PR TITLE
fix: handle ignored errors from operation.Save() and operation.List()

### DIFF
--- a/commander/commander.go
+++ b/commander/commander.go
@@ -91,7 +91,9 @@ func (c *Commander) handleActive(op *operation.Operation) {
 		op.FailureReason = &reason
 		op.PID = 0
 	}
-	operation.Save(op)
+	if err := operation.Save(op); err != nil {
+		log.Printf("[scan] %s: failed to save collected state: %v", op.OperationID, err)
+	}
 
 	if c.Notifier != nil && op.Status != "completed" {
 		msg := "Operation " + op.OperationID + " failed"

--- a/commander/dispatch.go
+++ b/commander/dispatch.go
@@ -35,7 +35,9 @@ func (c *Commander) Dispatch(brief, details string) (*operation.Operation, error
 				now := time.Now().UTC()
 				op.FailedAt = &now
 				op.FailureReason = &reason
-				operation.Save(op)
+				if err := operation.Save(op); err != nil {
+					log.Printf("[dispatch] %s: failed to save panic state: %v", op.OperationID, err)
+				}
 			}
 		}()
 		c.processOperation(op)
@@ -74,12 +76,16 @@ func (c *Commander) processOperation(op *operation.Operation) {
 	log.Printf("[dispatch] %s: launched successfully (squad=%s)", op.OperationID, reloaded.Squad)
 }
 
-func (c *Commander) failOperation(op *operation.Operation, reason string) {
+func (c *Commander) failOperation(op *operation.Operation, reason string) error {
 	now := time.Now().UTC()
 	op.Status = "failed"
 	op.FailedAt = &now
 	op.FailureReason = &reason
-	operation.Save(op)
+	if err := operation.Save(op); err != nil {
+		log.Printf("[dispatch] %s: failed to save failure state: %v", op.OperationID, err)
+		return fmt.Errorf("save failure state: %w", err)
+	}
+	return nil
 }
 
 // Cancel marks an operation as failed and kills the process if active.

--- a/commander/schedule/schedule.go
+++ b/commander/schedule/schedule.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -137,7 +138,10 @@ func CheckDue(dispatch DispatchFunc) {
 
 	// Build set of schedule IDs with in-flight operations
 	inFlight := make(map[string]bool)
-	ops, _ := operation.List()
+	ops, err := operation.List()
+	if err != nil {
+		log.Printf("[schedule] failed to list operations for duplicate detection: %v", err)
+	}
 	for _, op := range ops {
 		if op.Status == "queued" || op.Status == "active" {
 			if strings.HasPrefix(op.Source, "schedule/") {
@@ -166,7 +170,9 @@ func CheckDue(dispatch DispatchFunc) {
 		// Update the dispatched operation's source
 		if op, err := operation.Find(sourceTag); err == nil {
 			op.Source = "schedule/" + s.ID
-			_ = operation.Save(op)
+			if err := operation.Save(op); err != nil {
+				log.Printf("[schedule] %s: failed to save source update: %v", op.OperationID, err)
+			}
 		}
 
 		loc, _ := time.LoadLocation(s.Timezone)


### PR DESCRIPTION
## What
Fix inconsistent error handling for `SaveOperation()` and `ListOperations()` across the commander package.

## Why
Issue #62 findings #9 and #11 identified several call sites where errors from `SaveOperation()` and `ListOperations()` were silently ignored, which could mask I/O failures and cause duplicate scheduled dispatches.

## Changes
- **commander/dispatch.go**: `failOperation` now returns `error` and logs save failures internally. Panic recovery defer now checks and logs `SaveOperation` errors.
- **commander/collect.go**: `SaveOperation` error in the operation reaper is now checked and logged.
- **commander/schedule.go**: `ListOperations()` error in `CheckDue()` is now checked and logged (previously `_ =`). `SaveOperation` for source update is now checked and logged. Added `log` import.

## How to Test
```bash
go build -o /dev/null .
go vet ./...
```

Fixes #62 (findings #9, #11).