### PR TITLE
docs: split README uninstall section by OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,16 @@ If you use [OpenClaw](https://github.com/openclaw/openclaw), install the bridge 
 
 ## 🗑️ Uninstallation
 
+### Linux / macOS
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/LangSensei/swat/main/uninstall.sh | bash
+```
+
+### Windows
+
+```powershell
+irm https://raw.githubusercontent.com/LangSensei/swat/main/uninstall.ps1 | iex
 ```
 
 Add `--purge` to also remove runtime data (operation history).


### PR DESCRIPTION
## What
Split the README uninstall section into OS-specific subsections (Linux/macOS and Windows), matching the format of the install section.

## Why
The install section already distinguishes between Linux/macOS (`curl | bash`) and Windows (`irm | iex`) with separate subsections. The uninstall section only showed the bash command, which would not work on Windows. This brings the two sections into alignment.

## Changes
- `README.md`: Added "Linux / macOS" and "Windows" subsections under Uninstallation, with the appropriate commands for each OS

## Notes
- Both `uninstall.sh` and `uninstall.ps1` exist in the repository — no missing scripts.

## How to Test
1. Open the README and verify the Uninstallation section now mirrors the Installation section format
2. Confirm both `uninstall.sh` and `uninstall.ps1` URLs are correct