### PR TITLE
fix: add per-file flock to schedule Create/Delete/CheckDue

### DIFF
--- a/commander/schedule/schedule.go
+++ b/commander/schedule/schedule.go
@@ -136,16 +136,13 @@ func Delete(id string) error {
 	if err := fl.Lock(); err != nil {
 		return fmt.Errorf("acquire lock: %w", err)
 	}
+	defer fl.Unlock()
+	defer os.Remove(lp)
 
 	if !platform.FileExists(path) {
-		fl.Unlock()
 		return fmt.Errorf("schedule %q not found", id)
 	}
-	err := os.Remove(path)
-	fl.Unlock()
-	// Clean up the lock file after releasing the lock
-	os.Remove(lp)
-	return err
+	return os.Remove(path)
 }
 
 // CheckDue finds due schedules and dispatches them via the provided callback.
@@ -177,50 +174,47 @@ func CheckDue(dispatch DispatchFunc) {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
 			continue
 		}
-
 		id := strings.TrimSuffix(e.Name(), ".json")
-
-		// Per-file lock: skip this schedule if locked by another process
-		fl := flock.New(lockPath(id))
-		locked, err := fl.TryLock()
-		if err != nil || !locked {
-			continue
-		}
-
-		s, err := load(filepath.Join(dir, e.Name()))
-		if err != nil {
-			fl.Unlock()
-			continue
-		}
-
-		if !s.Enabled || s.NextRun == nil || s.NextRun.After(now) || inFlight[s.ID] {
-			fl.Unlock()
-			continue
-		}
-
-		sourceTag, err := dispatch(s.Brief, s.Details)
-		if err != nil {
-			fl.Unlock()
-			continue
-		}
-
-		// Update the dispatched operation's source
-		if op, err := operation.Find(sourceTag); err == nil {
-			op.Source = "schedule/" + s.ID
-			if err := operation.Save(op); err != nil {
-				log.Printf("[schedule] %s: failed to save source update: %v", op.OperationID, err)
-			}
-		}
-
-		loc, _ := time.LoadLocation(s.Timezone)
-		if loc == nil {
-			loc = time.UTC
-		}
-		s.LastRun = &now
-		s.NextRun = NextTime(s.Cron, now, loc)
-		_ = save(s)
-		fl.Unlock()
+		processSchedule(id, dir, now, inFlight, dispatch)
 	}
+}
+
+// processSchedule handles a single schedule entry with defer-based unlock.
+func processSchedule(id, dir string, now time.Time, inFlight map[string]bool, dispatch DispatchFunc) {
+	fl := flock.New(lockPath(id))
+	locked, err := fl.TryLock()
+	if err != nil || !locked {
+		return
+	}
+	defer fl.Unlock()
+
+	s, err := load(filepath.Join(dir, id+".json"))
+	if err != nil {
+		return
+	}
+
+	if !s.Enabled || s.NextRun == nil || s.NextRun.After(now) || inFlight[s.ID] {
+		return
+	}
+
+	sourceTag, err := dispatch(s.Brief, s.Details)
+	if err != nil {
+		return
+	}
+
+	// Update the dispatched operation's source
+	if op, err := operation.Find(sourceTag); err == nil {
+		op.Source = "schedule/" + s.ID
+		_ = operation.Save(op)
+	}
+
+	loc, _ := time.LoadLocation(s.Timezone)
+	if loc == nil {
+		loc = time.UTC
+	}
+	s.LastRun = &now
+	s.NextRun = NextTime(s.Cron, now, loc)
+	_ = save(s)
 }
 
 func filePath(id string) string {

--- a/commander/schedule/schedule.go
+++ b/commander/schedule/schedule.go
@@ -136,8 +136,10 @@ func Delete(id string) error {
 	if err := fl.Lock(); err != nil {
 		return fmt.Errorf("acquire lock: %w", err)
 	}
-	defer fl.Unlock()
-	defer os.Remove(lp)
+	defer func() {
+		fl.Unlock()
+		os.Remove(lp)
+	}()
 
 	if !platform.FileExists(path) {
 		return fmt.Errorf("schedule %q not found", id)

--- a/commander/schedule/schedule.go
+++ b/commander/schedule/schedule.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gofrs/flock"
+
 	"github.com/LangSensei/swat/commander/layout"
 	"github.com/LangSensei/swat/commander/operation"
 	"github.com/LangSensei/swat/commander/platform"
@@ -80,6 +82,13 @@ func Create(brief, details, cronExpr, tz string, immediate bool) (*Schedule, err
 	if err := os.MkdirAll(layout.SchedulesDir(), 0755); err != nil {
 		return nil, err
 	}
+
+	fl := flock.New(lockPath(id))
+	if err := fl.Lock(); err != nil {
+		return nil, fmt.Errorf("acquire lock: %w", err)
+	}
+	defer fl.Unlock()
+
 	return sched, save(sched)
 }
 
@@ -121,16 +130,29 @@ func List() ([]*Schedule, error) {
 // Delete removes a schedule by ID.
 func Delete(id string) error {
 	path := filePath(id)
+	lp := lockPath(id)
+
+	fl := flock.New(lp)
+	if err := fl.Lock(); err != nil {
+		return fmt.Errorf("acquire lock: %w", err)
+	}
+
 	if !platform.FileExists(path) {
+		fl.Unlock()
 		return fmt.Errorf("schedule %q not found", id)
 	}
-	return os.Remove(path)
+	err := os.Remove(path)
+	fl.Unlock()
+	// Clean up the lock file after releasing the lock
+	os.Remove(lp)
+	return err
 }
 
 // CheckDue finds due schedules and dispatches them via the provided callback.
 func CheckDue(dispatch DispatchFunc) {
-	schedules, err := List()
-	if err != nil || len(schedules) == 0 {
+	dir := layout.SchedulesDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil || len(entries) == 0 {
 		return
 	}
 
@@ -151,19 +173,34 @@ func CheckDue(dispatch DispatchFunc) {
 		}
 	}
 
-	for _, s := range schedules {
-		if !s.Enabled || s.NextRun == nil {
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
 			continue
 		}
-		if s.NextRun.After(now) {
+
+		id := strings.TrimSuffix(e.Name(), ".json")
+
+		// Per-file lock: skip this schedule if locked by another process
+		fl := flock.New(lockPath(id))
+		locked, err := fl.TryLock()
+		if err != nil || !locked {
 			continue
 		}
-		if inFlight[s.ID] {
+
+		s, err := load(filepath.Join(dir, e.Name()))
+		if err != nil {
+			fl.Unlock()
+			continue
+		}
+
+		if !s.Enabled || s.NextRun == nil || s.NextRun.After(now) || inFlight[s.ID] {
+			fl.Unlock()
 			continue
 		}
 
 		sourceTag, err := dispatch(s.Brief, s.Details)
 		if err != nil {
+			fl.Unlock()
 			continue
 		}
 
@@ -182,11 +219,16 @@ func CheckDue(dispatch DispatchFunc) {
 		s.LastRun = &now
 		s.NextRun = NextTime(s.Cron, now, loc)
 		_ = save(s)
+		fl.Unlock()
 	}
 }
 
 func filePath(id string) string {
 	return filepath.Join(layout.SchedulesDir(), id+".json")
+}
+
+func lockPath(id string) string {
+	return filepath.Join(layout.SchedulesDir(), id+".json.lock")
 }
 
 func save(s *Schedule) error {


### PR DESCRIPTION
## What
Add per-file advisory file locking to schedule `Create()`, `Delete()`, and `CheckDue()` using `gofrs/flock`.

## Why
Concurrent MCP server instances can race on schedule JSON files — a Create+CheckDue race can read partially-written JSON, and concurrent CheckDue instances can cause duplicate dispatches (issue #71 from the concurrency audit).

## Changes
- `commander/schedule/schedule.go`:
  - `Create()`: acquires flock on `xxx.json.lock` before writing
  - `Delete()`: acquires flock, removes JSON file, releases lock, cleans up lock file
  - `CheckDue()`: reads directory directly and uses `TryLock()` per schedule — skips locked schedules instead of blocking
  - Added `lockPath()` helper for consistent `.json.lock` sidecar paths

## How to Test
1. `go build -o /dev/null .` — verifies compilation
2. `go vet ./...` — passes static analysis
3. Manual: run two SWAT instances concurrently with overlapping schedule operations — no more partial reads or duplicate dispatches

Closes #71