### PR TITLE
docs: rename PROTOCOL step 4 from "Notify" to "Debrief"

### DIFF
--- a/blueprints/squads/_framework/PROTOCOL.md
+++ b/blueprints/squads/_framework/PROTOCOL.md
@@ -1,6 +1,6 @@
 ---
 name: protocol
-version: "2.0.1"
+version: "2.0.2"
 description: Base operation protocol — boot, execute, complete
 dependencies:
   skills: [debrief]
@@ -87,6 +87,6 @@ Generate `report.html` in the operation root. This is the **user-facing delivera
 - Responsive — readable on mobile and desktop (`<meta name="viewport">`)
 - Result-oriented — the reader wants answers, not a replay of your thought process
 
-### 4. Notify
+### 4. Debrief
 
-Read the debrief skill (`.github/skills/debrief/SKILL.md`) and follow its instructions to notify the user of results.
+Read the debrief skill (`.github/skills/debrief/SKILL.md`) and follow its instructions.


### PR DESCRIPTION
## What
Rename step 4 in `blueprints/squads/_framework/PROTOCOL.md` from "Notify" to "Debrief" and simplify its description. Bump version from 2.0.1 to 2.0.2.

## Why
The debrief skill (v3.1.0) now covers both Notify and Dispatch exits. The old step title "Notify" implied only notification, which no longer reflects the skill's full scope.

## Changes
- `blueprints/squads/_framework/PROTOCOL.md`: Renamed header, simplified description, bumped version

## How to Test
1. Open `blueprints/squads/_framework/PROTOCOL.md`
2. Verify step 4 is titled "Debrief" with simplified description
3. Verify frontmatter version is "2.0.2"