### PR TITLE
feat: return prereq warnings from squads.Update()

### DIFF
--- a/commander/squads/squads.go
+++ b/commander/squads/squads.go
@@ -214,15 +214,15 @@ func atomicDirReplace(remotePath, destDir string) error {
 // Update re-downloads a squad and its dependencies from the marketplace.
 // It uses an atomic directory swap (download to temp, then rename) so the
 // squad blueprint is never absent from disk during the update.
-func Update(squad string) error {
+func Update(squad string) ([]SkillPrereq, error) {
 	squadDir := layout.BlueprintSquadDir(squad)
 
 	if !platform.FileExists(filepath.Join(squadDir, "MANIFEST.md")) {
-		return fmt.Errorf("squad %q is not installed", squad)
+		return nil, fmt.Errorf("squad %q is not installed", squad)
 	}
 
 	if err := atomicDirReplace("squads/"+squad, squadDir); err != nil {
-		return fmt.Errorf("update squad %q: %w", squad, err)
+		return nil, fmt.Errorf("update squad %q: %w", squad, err)
 	}
 
 	allSkills := deps.ResolveSkillDependencies(squad)
@@ -230,7 +230,7 @@ func Update(squad string) error {
 	for _, skill := range allSkills {
 		destSkill := filepath.Join(layout.BlueprintSkillsDir(), skill)
 		if err := atomicDirReplace("skills/"+skill, destSkill); err != nil {
-			return fmt.Errorf("update skill %q: %w", skill, err)
+			return nil, fmt.Errorf("update skill %q: %w", skill, err)
 		}
 	}
 
@@ -240,15 +240,16 @@ func Update(squad string) error {
 		destMCP := filepath.Join(layout.BlueprintMCPsDir(), mcp+".json")
 		data, err := ghGetFile("mcps/" + mcp + ".json")
 		if err != nil {
-			return fmt.Errorf("download MCP %q: %w", mcp, err)
+			return nil, fmt.Errorf("download MCP %q: %w", mcp, err)
 		}
 		os.MkdirAll(layout.BlueprintMCPsDir(), 0755)
 		if err := os.WriteFile(destMCP, data, 0644); err != nil {
-			return fmt.Errorf("write MCP %q: %w", mcp, err)
+			return nil, fmt.Errorf("write MCP %q: %w", mcp, err)
 		}
 	}
 
-	return nil
+	prereqs := collectPrereqs(allSkills)
+	return prereqs, nil
 }
 
 // Uninstall removes a squad blueprint and cleans up orphaned dependencies.

--- a/mcp/handlers.go
+++ b/mcp/handlers.go
@@ -462,15 +462,25 @@ func (s *Server) handleUpdate(args map[string]interface{}) toolResult {
 		}
 	}
 
-	if err := squads.Update(squad); err != nil {
+	prereqs, err := squads.Update(squad)
+	if err != nil {
 		return toolResult{
 			Content: []contentBlock{{Type: "text", Text: fmt.Sprintf("update failed: %v", err)}},
 			IsError: true,
 		}
 	}
 
+	msg := fmt.Sprintf("squad %q updated to latest version", squad)
+	if len(prereqs) > 0 {
+		msg += "\n\n⚠️ Prerequisites needed:"
+		for _, p := range prereqs {
+			msg += fmt.Sprintf("\n- skill %q requires setup: %s", p.Skill, p.Path)
+		}
+		msg += "\n\nPlease complete these prerequisites before dispatching tasks."
+	}
+
 	return toolResult{
-		Content: []contentBlock{{Type: "text", Text: fmt.Sprintf("squad %q updated to latest version", squad)}},
+		Content: []contentBlock{{Type: "text", Text: msg}},
 	}
 }
 


### PR DESCRIPTION
## What
Return prerequisite warnings from `squads.Update()`, aligning it with `Install()`'s existing pattern.

## Why
`Update()` previously returned only `error` and did not check skill prerequisites after downloading. Users updating a squad with new skill dependencies that have prerequisites would not be warned. Fixes #82.

## Changes
- `commander/squads/squads.go`: Changed `Update()` return signature from `error` to `([]SkillPrereq, error)`. Added `collectPrereqs(allSkills)` call before final return. All error paths now return `nil, err`.
- `mcp/handlers.go`: Updated `handleUpdate` to capture prereqs and append warning messages to the response (mirrors `handleInstall` pattern).

## How to Test
1. Install a squad that has skills with `prereq:` in their frontmatter
2. Run `swat_squad_update` on that squad
3. Verify the response includes prerequisite warnings