### PR TITLE
fix: remove copilot CLI check from install scripts

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -39,11 +39,6 @@ function Check-Prereqs {
         Err "Missing prerequisites: $($missing -join ', ')"
         exit 1
     }
-
-    if (-not (Get-Command copilot -ErrorAction SilentlyContinue)) {
-        Warn "GitHub Copilot CLI not found. Required for running squads."
-        Info "  npm install -g @github/copilot"
-    }
 }
 
 # --- Download & Extract ---

--- a/install.sh
+++ b/install.sh
@@ -55,11 +55,6 @@ check_prereqs() {
     if [[ ${#missing[@]} -gt 0 ]]; then
         die "Missing prerequisites: ${missing[*]}"
     fi
-
-    if ! command -v copilot >/dev/null 2>&1; then
-        info "Warning: GitHub Copilot CLI not found. Required for running squads."
-        info "  npm install -g @github/copilot"
-    fi
 }
 
 # --- Download & Extract ---


### PR DESCRIPTION
## What
Remove the copilot CLI existence check from both `install.sh` and `install.ps1`.

## Why
swat supports multiple runtimes (copilot, gemini), so checking specifically for the copilot CLI is incorrect and misleading for non-copilot users. The "Next steps" output already shows `--runtime <name>` which provides sufficient guidance.

## Changes
- `install.sh`: Removed `command -v copilot` check and warning message (~lines 59-62)
- `install.ps1`: Removed `Get-Command copilot` check and warning message (~lines 43-46)

## How to Test
1. Run `install.sh` without copilot CLI installed — no warning should appear
2. Run `install.ps1` without copilot CLI installed — no warning should appear
3. Verify binary download, symlink, and blueprint install logic is unchanged
4. Verify "Next steps" output still shows `--runtime <name>`