### PR TITLE
refactor: rename task classifier to operation classifier with structured prompt

### DIFF
--- a/commander/pipeline/classify.go
+++ b/commander/pipeline/classify.go
@@ -14,7 +14,7 @@ import (
 	"github.com/LangSensei/swat/commander/squads"
 )
 
-// Classify runs the LLM-based classify+enrich step on an unclassified operation.
+// Classify runs the LLM-based operation classifier on an unclassified operation.
 func Classify(rt runtime.RuntimeAdapter, op *operation.Operation, notifier notify.Notifier) (*operation.Operation, string, error) {
 	unclassifiedDir := layout.UnclassifiedOperationDir(op.OperationID)
 
@@ -23,16 +23,34 @@ func Classify(rt runtime.RuntimeAdapter, op *operation.Operation, notifier notif
 	}
 
 	prompt := fmt.Sprintf(
-		"You are a task classifier and enricher. "+
-			"Read OPERATION.md in the current directory for the task. "+
-			"Read all MANIFEST.md files under %s (skip _framework) to find available squads. "+
-			"Read past operations under %s for historical context. "+
-			"Your job: "+
-			"1. Choose the best squad and update the 'squad' field in OPERATION.md frontmatter. "+
-			"2. If you find relevant historical operations, add them to the 'references' field as [{type: \"operation\", value: \"path\"}]. "+
-			"3. Write enrichment to the `### Context` section (under ## Assignment). Keep the ## Assignment text intact. Write historical context, related operation findings, and key metrics into ### Context, replacing the `[CLASSIFY: ...]` placeholder. "+
-			"If no squad is a good fit for the task, leave the squad field empty. "+
-			"Do NOT modify any other frontmatter fields besides 'squad' and 'references'.",
+		"You are an Operation Classifier. Your job is to route an operation to the right squad and enrich it with relevant context.\n\n"+
+			"## Step 1: Read the operation\n"+
+			"Read OPERATION.md for the brief (H1 title) and details (## Assignment section).\n\n"+
+			"## Step 2: Read available squads\n"+
+			"Read each MANIFEST.md under %s (skip _framework).\n"+
+			"For each squad, note: name, domain, description, skills.\n\n"+
+			"## Step 3: Match\n"+
+			"Choose the squad whose domain and description best matches the operation.\n"+
+			"Decision criteria (in priority order):\n"+
+			"1. Domain match — operation subject falls within squad's stated domain\n"+
+			"2. Skill match — operation requires skills the squad has\n"+
+			"3. Specificity — prefer more specific squad over general one\n\n"+
+			"If two squads tie, choose the one with more relevant historical operations.\n"+
+			"If no squad fits, leave squad field empty.\n\n"+
+			"## Step 4: Find references\n"+
+			"Scan OPERATION.md files from the matched squad's operations/ directory (%s).\n"+
+			"- First pass: read the frontmatter (status, summary) and the H1 title (brief) of all operations\n"+
+			"- Second pass: for the 5-10 most relevant completed operations, read full content\n"+
+			"- Add the most valuable ones as references (up to 10)\n\n"+
+			"## Step 5: Enrich context\n"+
+			"In the ### Context section, write:\n"+
+			"- Why this squad was chosen (1 sentence)\n"+
+			"- Key findings from referenced operations that are relevant to THIS operation\n"+
+			"- Any data points or metrics the operator should know before starting\n\n"+
+			"## Output\n"+
+			"Update OPERATION.md frontmatter: squad and references fields only.\n"+
+			"Replace the [CLASSIFY: ...] placeholder with your enrichment.\n"+
+			"Do NOT modify any other frontmatter fields.",
 		layout.BlueprintSquadsDir(),
 		layout.SquadsDir(),
 	)
@@ -49,14 +67,14 @@ func Classify(rt runtime.RuntimeAdapter, op *operation.Operation, notifier notif
 
 	if err := cmd.Start(); err != nil {
 		logFile.Close()
-		return nil, "", fmt.Errorf("start classify agent: %v", err)
+		return nil, "", fmt.Errorf("start operation classifier: %v", err)
 	}
 	if err := cmd.Wait(); err != nil {
 		logFile.Close()
-		log.Printf("[classify] %s: classify agent exited with error: %v", op.OperationID, err)
+		log.Printf("[classify] %s: operation classifier exited with error: %v", op.OperationID, err)
 	} else {
 		logFile.Close()
-		log.Printf("[classify] %s: classify agent completed successfully", op.OperationID)
+		log.Printf("[classify] %s: operation classifier completed successfully", op.OperationID)
 	}
 
 	reloaded, err := operation.Load("_unclassified", op.OperationID)


### PR DESCRIPTION
## What
Rename the classify prompt from "task classifier" to "Operation Classifier" and replace the single-paragraph prompt with a structured 5-step prompt.

## Why
The current classify prompt is a single paragraph with vague instructions. A structured prompt with explicit steps, decision criteria, and a two-pass reference scanning strategy will produce more consistent and higher-quality classification and enrichment results.

## Changes
- `commander/pipeline/classify.go`: Replace prompt string with structured 5-step prompt (read operation, read squads, match with priority criteria, find references with two-pass scan, enrich context). Rename "task classifier" to "Operation Classifier" in doc comment and log messages. No changes to function signature, file move logic, error handling, or notifier calls.

## How to Test
1. `go build -o /dev/null .` — verify compilation
2. Dispatch a new operation and verify classify still routes to the correct squad and produces enriched context