### PR TITLE
refactor: remove unused source field from OPERATION.md

### DIFF
--- a/blueprints/OPERATION.md
+++ b/blueprints/OPERATION.md
@@ -2,7 +2,6 @@
 # ── COMMANDER (written at dispatch, do not modify) ──
 # format: YYYYMMDD-8hex
 operation_id: {OPERATION_ID}
-source: {SOURCE}
 pid: {PID}
 created_at: {CREATED_AT}
 dispatched_at: {DISPATCHED_AT}

--- a/commander/commander.go
+++ b/commander/commander.go
@@ -112,7 +112,6 @@ func (c *Commander) dispatchForIntake(brief, details string) (string, error) {
 		Brief:       brief,
 		Details:     details,
 		Status:      "queued",
-		Source:      "user",
 		CreatedAt:   now,
 	}
 	if err := operation.Create(op); err != nil {

--- a/commander/dispatch.go
+++ b/commander/dispatch.go
@@ -20,7 +20,6 @@ func (c *Commander) Dispatch(brief, details string) (*operation.Operation, error
 		Brief:       brief,
 		Details:     details,
 		Status:      "queued",
-		Source:      "user",
 		CreatedAt:   now,
 	}
 	if err := operation.Create(op); err != nil {

--- a/commander/operation/operation.go
+++ b/commander/operation/operation.go
@@ -16,7 +16,6 @@ type Operation struct {
 	Squad         string      `json:"squad,omitempty"`
 	Status        string      `json:"status"`
 	PID           int         `json:"pid,omitempty"`
-	Source        string      `json:"source"`
 	CreatedAt     time.Time   `json:"created_at"`
 	DispatchedAt  *time.Time  `json:"dispatched_at,omitempty"`
 	CompletedAt   *time.Time  `json:"completed_at,omitempty"`
@@ -70,7 +69,6 @@ func Save(op *Operation) error {
 	patches := map[string]string{
 		"operation_id": op.OperationID,
 		"squad":        op.Squad,
-		"source":       op.Source,
 		"status":       op.Status,
 		"created_at":   op.CreatedAt.Format(time.RFC3339),
 	}

--- a/commander/operation/serialize.go
+++ b/commander/operation/serialize.go
@@ -24,8 +24,6 @@ func buildOperationFile(op *Operation) (string, error) {
 	// Commander fields
 	result = strings.ReplaceAll(result, "{OPERATION_ID}", op.OperationID)
 	result = strings.ReplaceAll(result, "{SQUAD}", op.Squad)
-	result = strings.ReplaceAll(result, "{SOURCE}", op.Source)
-
 	if op.PID > 0 {
 		result = strings.ReplaceAll(result, "{PID}", fmt.Sprintf("%d", op.PID))
 	} else {
@@ -101,8 +99,6 @@ func parseOperationMD(content string) (*Operation, error) {
 			op.Squad = val
 		case "status":
 			op.Status = val
-		case "source":
-			op.Source = val
 		case "pid":
 			fmt.Sscanf(val, "%d", &op.PID)
 		case "created_at":

--- a/commander/operation/serialize_test.go
+++ b/commander/operation/serialize_test.go
@@ -10,7 +10,6 @@ func TestParseOperationMD_BriefExtraction(t *testing.T) {
 		"operation_id: 20260415-test1234\n" +
 		"status: active\n" +
 		"squad: test-squad\n" +
-		"source: user\n" +
 		"created_at: 2026-04-15T06:00:00Z\n" +
 		"---\n" +
 		"\n" +


### PR DESCRIPTION
## What
Remove the unused `source` field from the OPERATION.md template, Go structs, and all serialization/deserialization code.

## Why
The `source` field was always set to `"user"` and never consumed by any code path (classify, provision, notify, report all ignore it). It carried zero information and added unnecessary clutter to the codebase.

## Changes
- `blueprints/OPERATION.md`: Remove `source: {SOURCE}` placeholder line
- `commander/operation/operation.go`: Remove `Source` field from Operation struct and `"source"` entry from Save() patches map
- `commander/operation/serialize.go`: Remove `{SOURCE}` template replacement in buildOperationFile() and `case "source"` branch in parseOperationMD()
- `commander/operation/serialize_test.go`: Remove `source: user` from test input strings
- `commander/commander.go`: Remove `Source: "user"` from dispatchForIntake literal
- `commander/dispatch.go`: Remove `Source: "user"` from Dispatch literal

## Backward Compatibility
Old OPERATION.md files with `source:` in frontmatter still parse without error — the deserializer switch has no default error handler, so unknown fields are silently skipped.

## How to Test
```bash
go build -o /dev/null .
go test ./...
```