### PR TITLE
refactor: non-blocking state machine for classify pipeline

### DIFF
--- a/blueprints/OPERATION.md
+++ b/blueprints/OPERATION.md
@@ -14,7 +14,7 @@ squad: {SQUAD}
 references: {REFERENCES}
 
 # ── OPERATOR (fill during execution) ──
-# queued → active → completed / failed
+# queued → classifying → active → completed / failed
 status: {STATUS}
 # 2-3 sentence summary of outcome
 summary: {SUMMARY}

--- a/commander/commander.go
+++ b/commander/commander.go
@@ -84,7 +84,7 @@ func (c *Commander) scan() {
 		case "classifying":
 			if !platform.ProcessAlive(op.PID) {
 				c.withLock(op, layout.UnclassifiedOperationDir(op.OperationID), "classifying", func(reloaded *operation.Operation) {
-					if err := pipeline.Advance(rt, reloaded, c.Notifier, c.RuntimeName, c.NotifyName); err != nil {
+					if err := pipeline.Advance(rt, reloaded, c.RuntimeName, c.NotifyName); err != nil {
 						c.failOperation(reloaded, err.Error())
 					}
 				})
@@ -96,9 +96,13 @@ func (c *Commander) scan() {
 			c.withLock(op, layout.OperationDir(op.Squad, op.OperationID), "active", func(reloaded *operation.Operation) {
 				if err := pipeline.Collect(reloaded); err != nil {
 					log.Printf("[scan] %s: collect save error: %v", reloaded.OperationID, err)
+					return
 				}
+				// Collect sets status — if it's "failed", Collect already saved it,
+				// but we still need to notify. Use Notifier directly since Save already done.
 				if reloaded.Status == "failed" && c.Notifier != nil {
-					msg := "Operation " + reloaded.OperationID + " failed"
+					reason := "process_exited_without_completion"
+					msg := fmt.Sprintf("Operation %s failed: %s", reloaded.OperationID, reason)
 					if err := c.Notifier.Notify(msg); err != nil {
 						log.Printf("[scan] notify error: %v", err)
 					}

--- a/commander/commander.go
+++ b/commander/commander.go
@@ -14,6 +14,7 @@ import (
 	"github.com/LangSensei/swat/commander/pipeline"
 	"github.com/LangSensei/swat/commander/platform"
 	"github.com/LangSensei/swat/commander/runtime"
+	"github.com/gofrs/flock"
 )
 
 // Commander is the core orchestrator
@@ -55,7 +56,7 @@ func (c *Commander) BackgroundLoop(interval time.Duration) {
 
 	for range ticker.C {
 		c.scan()
-		intake.ProcessDue(c.dispatchForIntake, c.processExistingOperation)
+		intake.ProcessDue(c.dispatchForIntake, nil)
 	}
 }
 
@@ -81,41 +82,68 @@ func (c *Commander) scan() {
 
 // spawnClassify starts the classifier subprocess for a queued operation.
 func (c *Commander) spawnClassify(op *operation.Operation) {
-	rt, err := runtime.New(c.RuntimeName)
-	if err != nil {
-		c.failOperation(op, fmt.Sprintf("init runtime: %v", err))
+	opDir := layout.UnclassifiedOperationDir(op.OperationID)
+	lockPath := filepath.Join(opDir, ".lock")
+	fl := flock.New(lockPath)
+	locked, err := fl.TryLock()
+	if !locked || err != nil {
 		return
 	}
-	if err := pipeline.SpawnClassify(rt, op); err != nil {
-		c.failOperation(op, fmt.Sprintf("classify spawn: %v", err))
+	defer fl.Unlock()
+
+	reloaded, err := operation.Load("_unclassified", op.OperationID)
+	if err != nil || reloaded.Status != "queued" {
+		return
+	}
+
+	rt, err := runtime.New(c.RuntimeName)
+	if err != nil {
+		c.failOperation(reloaded, fmt.Sprintf("init runtime: %v", err))
+		return
+	}
+	if err := pipeline.SpawnClassify(rt, reloaded); err != nil {
+		c.failOperation(reloaded, fmt.Sprintf("classify spawn: %v", err))
 	}
 }
 
 // finishClassify completes the classify phase and runs provision + launch.
 func (c *Commander) finishClassify(op *operation.Operation) {
+	opDir := layout.UnclassifiedOperationDir(op.OperationID)
+	lockPath := filepath.Join(opDir, ".lock")
+	fl := flock.New(lockPath)
+	locked, err := fl.TryLock()
+	if !locked || err != nil {
+		return
+	}
+	defer fl.Unlock()
+
+	reloaded, err := operation.Load("_unclassified", op.OperationID)
+	if err != nil || reloaded.Status != "classifying" {
+		return
+	}
+
 	rt, err := runtime.New(c.RuntimeName)
 	if err != nil {
-		c.failOperation(op, fmt.Sprintf("init runtime: %v", err))
+		c.failOperation(reloaded, fmt.Sprintf("init runtime: %v", err))
 		return
 	}
 
-	reloaded, destDir, err := pipeline.FinishClassify(op, c.Notifier)
+	classified, destDir, err := pipeline.FinishClassify(reloaded, c.Notifier)
 	if err != nil {
-		// Use original op (still in _unclassified) for failure path
-		c.failOperation(op, err.Error())
+		c.failOperation(reloaded, err.Error())
 		return
 	}
 
-	if err := pipeline.Provision(rt, reloaded, destDir, c.RuntimeName, c.NotifyName); err != nil {
-		c.failOperation(reloaded, fmt.Sprintf("provision: %v", err))
+	if err := pipeline.Provision(rt, classified, destDir, c.RuntimeName, c.NotifyName); err != nil {
+		c.failOperation(classified, fmt.Sprintf("provision: %v", err))
 		return
 	}
 
-	if err := pipeline.LaunchAgent(rt, reloaded, destDir); err != nil {
-		c.failOperation(reloaded, fmt.Sprintf("launch: %v", err))
+	if err := pipeline.LaunchAgent(rt, classified, destDir); err != nil {
+		c.failOperation(classified, fmt.Sprintf("launch: %v", err))
 		return
 	}
-	log.Printf("[scan] %s: launched successfully (squad=%s)", reloaded.OperationID, reloaded.Squad)
+	log.Printf("[scan] %s: launched successfully (squad=%s)", classified.OperationID, classified.Squad)
 }
 
 func (c *Commander) handleActive(op *operation.Operation) {
@@ -123,28 +151,41 @@ func (c *Commander) handleActive(op *operation.Operation) {
 		return
 	}
 
-	now := time.Now().UTC()
 	opDir := layout.OperationDir(op.Squad, op.OperationID)
+	lockPath := filepath.Join(opDir, ".lock")
+	fl := flock.New(lockPath)
+	locked, err := fl.TryLock()
+	if !locked || err != nil {
+		return
+	}
+	defer fl.Unlock()
+
+	reloaded, err := operation.Load(op.Squad, op.OperationID)
+	if err != nil || reloaded.Status != "active" {
+		return
+	}
+
+	now := time.Now().UTC()
 	reportExists := platform.FileExists(filepath.Join(opDir, "report.html"))
-	opCompleted := platform.FileContains(layout.OperationMDPath(op.Squad, op.OperationID), "status: completed")
+	opCompleted := platform.FileContains(layout.OperationMDPath(reloaded.Squad, reloaded.OperationID), "status: completed")
 
 	if reportExists && opCompleted {
-		op.Status = "completed"
-		op.CompletedAt = &now
-		op.PID = 0
+		reloaded.Status = "completed"
+		reloaded.CompletedAt = &now
+		reloaded.PID = 0
 	} else {
 		reason := "process_exited_without_completion"
-		op.Status = "failed"
-		op.FailedAt = &now
-		op.FailureReason = &reason
-		op.PID = 0
+		reloaded.Status = "failed"
+		reloaded.FailedAt = &now
+		reloaded.FailureReason = &reason
+		reloaded.PID = 0
 	}
-	if err := operation.Save(op); err != nil {
-		log.Printf("[scan] %s: failed to save collected state: %v", op.OperationID, err)
+	if err := operation.Save(reloaded); err != nil {
+		log.Printf("[scan] %s: failed to save collected state: %v", reloaded.OperationID, err)
 	}
 
-	if c.Notifier != nil && op.Status != "completed" {
-		msg := "Operation " + op.OperationID + " failed"
+	if c.Notifier != nil && reloaded.Status != "completed" {
+		msg := "Operation " + reloaded.OperationID + " failed"
 		if err := c.Notifier.Notify(msg); err != nil {
 			log.Printf("[scan] notify error: %v", err)
 		}
@@ -168,8 +209,4 @@ func (c *Commander) dispatchForIntake(brief, details string) (string, error) {
 	return op.OperationID, nil
 }
 
-// processExistingOperation is the callback used by intake.ProcessDue for immediate tasks.
-// The operation already exists with status "queued" — the scan loop will pick it up.
-func (c *Commander) processExistingOperation(operationID string) error {
-	return nil
-}
+

--- a/commander/commander.go
+++ b/commander/commander.go
@@ -63,26 +63,61 @@ func (c *Commander) BackgroundLoop(interval time.Duration) {
 func (c *Commander) scan() {
 	ops, err := operation.List()
 	if err != nil {
-		log.Printf("[scan] error: %v", err)
+		log.Printf("[scan] list error: %v", err)
 		return
 	}
+
+	rt, err := runtime.New(c.RuntimeName)
+	if err != nil {
+		log.Printf("[scan] init runtime: %v", err)
+		return
+	}
+
 	for _, op := range ops {
 		switch op.Status {
 		case "queued":
-			c.spawnClassify(op)
+			c.withLock(op, layout.UnclassifiedOperationDir(op.OperationID), "queued", func(reloaded *operation.Operation) {
+				if err := pipeline.SpawnClassify(rt, reloaded); err != nil {
+					c.failOperation(reloaded, fmt.Sprintf("classify spawn: %v", err))
+				}
+			})
 		case "classifying":
 			if !platform.ProcessAlive(op.PID) {
-				c.finishClassify(op)
+				c.withLock(op, layout.UnclassifiedOperationDir(op.OperationID), "classifying", func(reloaded *operation.Operation) {
+					if err := pipeline.Advance(rt, reloaded, c.Notifier, c.RuntimeName, c.NotifyName); err != nil {
+						c.failOperation(reloaded, err.Error())
+					}
+				})
 			}
 		case "active":
-			c.handleActive(op)
+			if op.PID > 0 && platform.ProcessAlive(op.PID) {
+				continue
+			}
+			c.withLock(op, layout.OperationDir(op.Squad, op.OperationID), "active", func(reloaded *operation.Operation) {
+				if err := pipeline.Collect(reloaded); err != nil {
+					log.Printf("[scan] %s: collect save error: %v", reloaded.OperationID, err)
+				}
+				if reloaded.Status == "failed" && c.Notifier != nil {
+					msg := "Operation " + reloaded.OperationID + " failed"
+					if err := c.Notifier.Notify(msg); err != nil {
+						log.Printf("[scan] notify error: %v", err)
+					}
+				}
+			})
 		}
 	}
 }
 
-// spawnClassify starts the classifier subprocess for a queued operation.
-func (c *Commander) spawnClassify(op *operation.Operation) {
-	opDir := layout.UnclassifiedOperationDir(op.OperationID)
+// withLock acquires a per-operation flock, double-checks status, and calls fn.
+// Recovers from panics to prevent BackgroundLoop from crashing.
+func (c *Commander) withLock(op *operation.Operation, opDir string, expectedStatus string, fn func(reloaded *operation.Operation)) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("[scan] PANIC in %s: %v", op.OperationID, r)
+			c.failOperation(op, fmt.Sprintf("panic: %v", r))
+		}
+	}()
+
 	lockPath := filepath.Join(opDir, ".lock")
 	fl := flock.New(lockPath)
 	locked, err := fl.TryLock()
@@ -91,105 +126,17 @@ func (c *Commander) spawnClassify(op *operation.Operation) {
 	}
 	defer fl.Unlock()
 
-	reloaded, err := operation.Load("_unclassified", op.OperationID)
-	if err != nil || reloaded.Status != "queued" {
-		return
-	}
-
-	rt, err := runtime.New(c.RuntimeName)
-	if err != nil {
-		c.failOperation(reloaded, fmt.Sprintf("init runtime: %v", err))
-		return
-	}
-	if err := pipeline.SpawnClassify(rt, reloaded); err != nil {
-		c.failOperation(reloaded, fmt.Sprintf("classify spawn: %v", err))
-	}
-}
-
-// finishClassify completes the classify phase and runs provision + launch.
-func (c *Commander) finishClassify(op *operation.Operation) {
-	opDir := layout.UnclassifiedOperationDir(op.OperationID)
-	lockPath := filepath.Join(opDir, ".lock")
-	fl := flock.New(lockPath)
-	locked, err := fl.TryLock()
-	if !locked || err != nil {
-		return
-	}
-	defer fl.Unlock()
-
-	reloaded, err := operation.Load("_unclassified", op.OperationID)
-	if err != nil || reloaded.Status != "classifying" {
-		return
-	}
-
-	rt, err := runtime.New(c.RuntimeName)
-	if err != nil {
-		c.failOperation(reloaded, fmt.Sprintf("init runtime: %v", err))
-		return
-	}
-
-	classified, destDir, err := pipeline.FinishClassify(reloaded, c.Notifier)
-	if err != nil {
-		c.failOperation(reloaded, err.Error())
-		return
-	}
-
-	if err := pipeline.Provision(rt, classified, destDir, c.RuntimeName, c.NotifyName); err != nil {
-		c.failOperation(classified, fmt.Sprintf("provision: %v", err))
-		return
-	}
-
-	if err := pipeline.LaunchAgent(rt, classified, destDir); err != nil {
-		c.failOperation(classified, fmt.Sprintf("launch: %v", err))
-		return
-	}
-	log.Printf("[scan] %s: launched successfully (squad=%s)", classified.OperationID, classified.Squad)
-}
-
-func (c *Commander) handleActive(op *operation.Operation) {
-	if op.PID > 0 && platform.ProcessAlive(op.PID) {
-		return
-	}
-
-	opDir := layout.OperationDir(op.Squad, op.OperationID)
-	lockPath := filepath.Join(opDir, ".lock")
-	fl := flock.New(lockPath)
-	locked, err := fl.TryLock()
-	if !locked || err != nil {
-		return
-	}
-	defer fl.Unlock()
-
-	reloaded, err := operation.Load(op.Squad, op.OperationID)
-	if err != nil || reloaded.Status != "active" {
-		return
-	}
-
-	now := time.Now().UTC()
-	reportExists := platform.FileExists(filepath.Join(opDir, "report.html"))
-	opCompleted := platform.FileContains(layout.OperationMDPath(reloaded.Squad, reloaded.OperationID), "status: completed")
-
-	if reportExists && opCompleted {
-		reloaded.Status = "completed"
-		reloaded.CompletedAt = &now
-		reloaded.PID = 0
+	var reloaded *operation.Operation
+	if expectedStatus == "queued" || expectedStatus == "classifying" {
+		reloaded, err = operation.Load("_unclassified", op.OperationID)
 	} else {
-		reason := "process_exited_without_completion"
-		reloaded.Status = "failed"
-		reloaded.FailedAt = &now
-		reloaded.FailureReason = &reason
-		reloaded.PID = 0
+		reloaded, err = operation.Load(op.Squad, op.OperationID)
 	}
-	if err := operation.Save(reloaded); err != nil {
-		log.Printf("[scan] %s: failed to save collected state: %v", reloaded.OperationID, err)
+	if err != nil || reloaded.Status != expectedStatus {
+		return
 	}
 
-	if c.Notifier != nil && reloaded.Status != "completed" {
-		msg := "Operation " + reloaded.OperationID + " failed"
-		if err := c.Notifier.Notify(msg); err != nil {
-			log.Printf("[scan] notify error: %v", err)
-		}
-	}
+	fn(reloaded)
 }
 
 // dispatchForIntake is the callback used by intake.ProcessDue for recurring tasks.

--- a/commander/commander.go
+++ b/commander/commander.go
@@ -11,7 +11,9 @@ import (
 	"github.com/LangSensei/swat/commander/layout"
 	"github.com/LangSensei/swat/commander/notify"
 	"github.com/LangSensei/swat/commander/operation"
+	"github.com/LangSensei/swat/commander/pipeline"
 	"github.com/LangSensei/swat/commander/platform"
+	"github.com/LangSensei/swat/commander/runtime"
 )
 
 // Commander is the core orchestrator
@@ -64,10 +66,56 @@ func (c *Commander) scan() {
 		return
 	}
 	for _, op := range ops {
-		if op.Status == "active" {
+		switch op.Status {
+		case "queued":
+			c.spawnClassify(op)
+		case "classifying":
+			if !platform.ProcessAlive(op.PID) {
+				c.finishClassify(op)
+			}
+		case "active":
 			c.handleActive(op)
 		}
 	}
+}
+
+// spawnClassify starts the classifier subprocess for a queued operation.
+func (c *Commander) spawnClassify(op *operation.Operation) {
+	rt, err := runtime.New(c.RuntimeName)
+	if err != nil {
+		c.failOperation(op, fmt.Sprintf("init runtime: %v", err))
+		return
+	}
+	if err := pipeline.SpawnClassify(rt, op); err != nil {
+		c.failOperation(op, fmt.Sprintf("classify spawn: %v", err))
+	}
+}
+
+// finishClassify completes the classify phase and runs provision + launch.
+func (c *Commander) finishClassify(op *operation.Operation) {
+	rt, err := runtime.New(c.RuntimeName)
+	if err != nil {
+		c.failOperation(op, fmt.Sprintf("init runtime: %v", err))
+		return
+	}
+
+	reloaded, destDir, err := pipeline.FinishClassify(op, c.Notifier)
+	if err != nil {
+		// Use original op (still in _unclassified) for failure path
+		c.failOperation(op, err.Error())
+		return
+	}
+
+	if err := pipeline.Provision(rt, reloaded, destDir, c.RuntimeName, c.NotifyName); err != nil {
+		c.failOperation(reloaded, fmt.Sprintf("provision: %v", err))
+		return
+	}
+
+	if err := pipeline.LaunchAgent(rt, reloaded, destDir); err != nil {
+		c.failOperation(reloaded, fmt.Sprintf("launch: %v", err))
+		return
+	}
+	log.Printf("[scan] %s: launched successfully (squad=%s)", reloaded.OperationID, reloaded.Squad)
 }
 
 func (c *Commander) handleActive(op *operation.Operation) {
@@ -104,7 +152,7 @@ func (c *Commander) handleActive(op *operation.Operation) {
 }
 
 // dispatchForIntake is the callback used by intake.ProcessDue for recurring tasks.
-// It creates a new operation and runs the full pipeline: classify → provision → launch.
+// It creates a new operation with status "queued". The scan loop picks it up.
 func (c *Commander) dispatchForIntake(brief, details string) (string, error) {
 	now := time.Now().UTC()
 	op := &operation.Operation{
@@ -117,19 +165,11 @@ func (c *Commander) dispatchForIntake(brief, details string) (string, error) {
 	if err := operation.Create(op); err != nil {
 		return "", err
 	}
-
-	c.processOperation(op)
 	return op.OperationID, nil
 }
 
 // processExistingOperation is the callback used by intake.ProcessDue for immediate tasks.
-// It loads an existing operation and runs the pipeline on it.
+// The operation already exists with status "queued" — the scan loop will pick it up.
 func (c *Commander) processExistingOperation(operationID string) error {
-	op, err := operation.Find(operationID)
-	if err != nil {
-		return fmt.Errorf("find operation %s: %w", operationID, err)
-	}
-
-	c.processOperation(op)
 	return nil
 }

--- a/commander/dispatch.go
+++ b/commander/dispatch.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/LangSensei/swat/commander/intake"
 	"github.com/LangSensei/swat/commander/operation"
-	"github.com/LangSensei/swat/commander/pipeline"
-	"github.com/LangSensei/swat/commander/runtime"
 )
 
 // Dispatch creates a new operation and queues it for processing via the intake queue.
@@ -33,58 +31,28 @@ func (c *Commander) Dispatch(brief, details string) (*operation.Operation, error
 	return op, nil
 }
 
-// processOperation runs the classify → provision → launch pipeline for an operation.
-// Recovers from panics to prevent BackgroundLoop from crashing.
-func (c *Commander) processOperation(op *operation.Operation) {
-	defer func() {
-		if r := recover(); r != nil {
-			log.Printf("[dispatch] PANIC in processOperation %s: %v", op.OperationID, r)
-			c.failOperation(op, fmt.Sprintf("panic: %v", r))
-		}
-	}()
-
-	log.Printf("[dispatch] processOperation started: %s", op.OperationID)
-
-	rt, err := runtime.New(c.RuntimeName)
-	if err != nil {
-		c.failOperation(op, fmt.Sprintf("init runtime: %v", err))
-		return
-	}
-
-	reloaded, destDir, err := pipeline.Classify(rt, op, c.Notifier)
-	if err != nil {
-		log.Printf("[dispatch] %s: classify failed: %v", op.OperationID, err)
-		c.failOperation(op, err.Error())
-		return
-	}
-
-	if err := pipeline.Provision(rt, reloaded, destDir, c.RuntimeName, c.NotifyName); err != nil {
-		log.Printf("[dispatch] %s: provision failed: %v", op.OperationID, err)
-		c.failOperation(reloaded, fmt.Sprintf("provision: %v", err))
-		return
-	}
-
-	if err := pipeline.LaunchAgent(rt, reloaded, destDir); err != nil {
-		log.Printf("[dispatch] %s: launch failed: %v", op.OperationID, err)
-		c.failOperation(reloaded, fmt.Sprintf("launch: %v", err))
-		return
-	}
-	log.Printf("[dispatch] %s: launched successfully (squad=%s)", op.OperationID, reloaded.Squad)
-}
-
 func (c *Commander) failOperation(op *operation.Operation, reason string) error {
 	now := time.Now().UTC()
 	op.Status = "failed"
 	op.FailedAt = &now
 	op.FailureReason = &reason
+	op.PID = 0
 	if err := operation.Save(op); err != nil {
 		log.Printf("[dispatch] %s: failed to save failure state: %v", op.OperationID, err)
 		return fmt.Errorf("save failure state: %w", err)
 	}
+
+	if c.Notifier != nil {
+		msg := fmt.Sprintf("Operation %s failed: %s", op.OperationID, reason)
+		if err := c.Notifier.Notify(msg); err != nil {
+			log.Printf("[dispatch] %s: notify error: %v", op.OperationID, err)
+		}
+	}
+
 	return nil
 }
 
-// Cancel marks an operation as failed and kills the process if active.
+// Cancel marks an operation as failed and kills the process if active or classifying.
 func (c *Commander) Cancel(opID string) error {
 	op, err := operation.Find(opID)
 	if err != nil {
@@ -93,7 +61,7 @@ func (c *Commander) Cancel(opID string) error {
 	now := time.Now().UTC()
 	reason := "cancelled_by_user"
 
-	if op.Status == "active" && op.PID > 0 {
+	if (op.Status == "active" || op.Status == "classifying") && op.PID > 0 {
 		if p, err := os.FindProcess(op.PID); err == nil {
 			p.Signal(os.Kill)
 		}
@@ -102,5 +70,6 @@ func (c *Commander) Cancel(opID string) error {
 	op.Status = "failed"
 	op.FailedAt = &now
 	op.FailureReason = &reason
+	op.PID = 0
 	return operation.Save(op)
 }

--- a/commander/intake/intake.go
+++ b/commander/intake/intake.go
@@ -250,12 +250,14 @@ func processImmediate(item *Immediate, processFn ProcessFunc, fl *flock.Flock) {
 		os.Remove(lockPath(item.ID))
 	}()
 
-	if err := processFn(item.OperationID); err != nil {
-		log.Printf("[intake] immediate %s: process failed: %v", item.ID, err)
-		return
+	if processFn != nil {
+		if err := processFn(item.OperationID); err != nil {
+			log.Printf("[intake] immediate %s: process failed: %v", item.ID, err)
+			return
+		}
 	}
 
-	// Delete the intake file after successful processing
+	// Delete the intake file
 	if err := os.Remove(jsonPath(item.ID)); err != nil {
 		log.Printf("[intake] immediate %s: failed to remove intake file: %v", item.ID, err)
 	}

--- a/commander/operation/operation.go
+++ b/commander/operation/operation.go
@@ -70,10 +70,8 @@ func Save(op *Operation) error {
 		"operation_id": op.OperationID,
 		"squad":        op.Squad,
 		"status":       op.Status,
+		"pid":          fmt.Sprintf("%d", op.PID),
 		"created_at":   op.CreatedAt.Format(time.RFC3339),
-	}
-	if op.PID > 0 {
-		patches["pid"] = fmt.Sprintf("%d", op.PID)
 	}
 	if op.DispatchedAt != nil {
 		patches["dispatched_at"] = op.DispatchedAt.Format(time.RFC3339)

--- a/commander/pipeline/classify.go
+++ b/commander/pipeline/classify.go
@@ -61,12 +61,13 @@ func SpawnClassify(rt runtime.RuntimeAdapter, op *operation.Operation) error {
 	return nil
 }
 
-// FinishClassify completes the classify phase after the classifier process has exited.
-// It reloads OPERATION.md, checks the squad assignment, and moves the operation to the squad directory.
-func FinishClassify(op *operation.Operation, notifier notify.Notifier) (*operation.Operation, string, error) {
+// Advance completes classify and transitions an operation from classifying → active.
+// Reloads OPERATION.md to get classifier output, validates squad, moves to squad dir,
+// provisions, and launches the agent.
+func Advance(rt runtime.RuntimeAdapter, op *operation.Operation, notifier notify.Notifier, runtimeName, notifyName string) error {
 	reloaded, err := operation.Load("_unclassified", op.OperationID)
 	if err != nil {
-		return nil, "", fmt.Errorf("reload after classify: %v", err)
+		return fmt.Errorf("reload after classify: %v", err)
 	}
 	log.Printf("[classify] %s: classify result — squad=%q", op.OperationID, reloaded.Squad)
 
@@ -75,7 +76,7 @@ func FinishClassify(op *operation.Operation, notifier notify.Notifier) (*operati
 		if notifier != nil {
 			notifier.Notify(fmt.Sprintf("Task could not be classified — no matching squad found.\n\nOperation: %s\nBrief: %s\n\nInstalled squads:\n%s", op.OperationID, op.Brief, summaries))
 		}
-		return nil, "", fmt.Errorf("classify failed: no squad assigned")
+		return fmt.Errorf("classify failed: no squad assigned")
 	}
 
 	manifestPath := filepath.Join(layout.BlueprintSquadDir(reloaded.Squad), "MANIFEST.md")
@@ -83,18 +84,27 @@ func FinishClassify(op *operation.Operation, notifier notify.Notifier) (*operati
 		if notifier != nil {
 			notifier.Notify(fmt.Sprintf("Task classified to squad '%s' which is not installed.\n\nOperation: %s\nBrief: %s", reloaded.Squad, op.OperationID, op.Brief))
 		}
-		return nil, "", fmt.Errorf("classify assigned unknown squad: %s", reloaded.Squad)
+		return fmt.Errorf("classify assigned unknown squad: %s", reloaded.Squad)
 	}
 
 	destDir := layout.OperationDir(reloaded.Squad, op.OperationID)
 	if err := os.MkdirAll(filepath.Dir(destDir), 0755); err != nil {
-		return nil, "", fmt.Errorf("create squad dir: %v", err)
+		return fmt.Errorf("create squad dir: %v", err)
 	}
 	if err := os.Rename(layout.UnclassifiedOperationDir(op.OperationID), destDir); err != nil {
-		return nil, "", fmt.Errorf("move to squad: %v", err)
+		return fmt.Errorf("move to squad: %v", err)
 	}
 
-	return reloaded, destDir, nil
+	if err := Provision(rt, reloaded, destDir, runtimeName, notifyName); err != nil {
+		return fmt.Errorf("provision: %v", err)
+	}
+
+	if err := LaunchAgent(rt, reloaded, destDir); err != nil {
+		return fmt.Errorf("launch: %v", err)
+	}
+
+	log.Printf("[scan] %s: launched successfully (squad=%s)", reloaded.OperationID, reloaded.Squad)
+	return nil
 }
 
 // buildClassifyPrompt constructs the classifier system prompt.

--- a/commander/pipeline/classify.go
+++ b/commander/pipeline/classify.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/LangSensei/swat/commander/layout"
-	"github.com/LangSensei/swat/commander/notify"
 	"github.com/LangSensei/swat/commander/operation"
 	"github.com/LangSensei/swat/commander/platform"
 	"github.com/LangSensei/swat/commander/runtime"
@@ -64,23 +63,17 @@ func SpawnClassify(rt runtime.RuntimeAdapter, op *operation.Operation) error {
 // Advance completes classify and transitions an operation from classifying → active.
 // Reloads OPERATION.md to get classifier output, validates squad, moves to squad dir,
 // provisions, and launches the agent.
-func Advance(rt runtime.RuntimeAdapter, op *operation.Operation, notifier notify.Notifier, runtimeName, notifyName string) error {
+func Advance(rt runtime.RuntimeAdapter, op *operation.Operation, runtimeName, notifyName string) error {
 	log.Printf("[classify] %s: classify result — squad=%q", op.OperationID, op.Squad)
 
 	if op.Squad == "" {
 		summaries := squads.ListSummaries()
-		if notifier != nil {
-			notifier.Notify(fmt.Sprintf("Task could not be classified — no matching squad found.\n\nOperation: %s\nBrief: %s\n\nInstalled squads:\n%s", op.OperationID, op.Brief, summaries))
-		}
-		return fmt.Errorf("classify failed: no squad assigned")
+		return fmt.Errorf("no matching squad found\n\nInstalled squads:\n%s", summaries)
 	}
 
 	manifestPath := filepath.Join(layout.BlueprintSquadDir(op.Squad), "MANIFEST.md")
 	if !platform.FileExists(manifestPath) {
-		if notifier != nil {
-			notifier.Notify(fmt.Sprintf("Task classified to squad '%s' which is not installed.\n\nOperation: %s\nBrief: %s", op.Squad, op.OperationID, op.Brief))
-		}
-		return fmt.Errorf("classify assigned unknown squad: %s", op.Squad)
+		return fmt.Errorf("classified to squad '%s' which is not installed", op.Squad)
 	}
 
 	destDir := layout.OperationDir(op.Squad, op.OperationID)

--- a/commander/pipeline/classify.go
+++ b/commander/pipeline/classify.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/LangSensei/swat/commander/layout"
 	"github.com/LangSensei/swat/commander/notify"
@@ -14,15 +15,96 @@ import (
 	"github.com/LangSensei/swat/commander/squads"
 )
 
-// Classify runs the LLM-based operation classifier on an unclassified operation.
-func Classify(rt runtime.RuntimeAdapter, op *operation.Operation, notifier notify.Notifier) (*operation.Operation, string, error) {
+// SpawnClassify starts the LLM-based operation classifier as a non-blocking subprocess.
+// It saves the classify PID and sets status to "classifying", then returns immediately.
+func SpawnClassify(rt runtime.RuntimeAdapter, op *operation.Operation) error {
 	unclassifiedDir := layout.UnclassifiedOperationDir(op.OperationID)
 
 	if err := rt.PrepareWorkspace(unclassifiedDir, runtime.PhaseClassify); err != nil {
-		return nil, "", fmt.Errorf("prepare workspace (classify): %v", err)
+		return fmt.Errorf("prepare workspace (classify): %v", err)
 	}
 
-	prompt := fmt.Sprintf(
+	prompt := buildClassifyPrompt()
+
+	cmd := rt.BuildCommand(prompt, unclassifiedDir)
+
+	logPath := filepath.Join(unclassifiedDir, "classify.log")
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		return fmt.Errorf("create classify log: %v", err)
+	}
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	if err := cmd.Start(); err != nil {
+		logFile.Close()
+		return fmt.Errorf("start operation classifier: %v", err)
+	}
+
+	now := time.Now().UTC()
+	op.Status = "classifying"
+	op.PID = cmd.Process.Pid
+	op.DispatchedAt = &now
+
+	if err := operation.Save(op); err != nil {
+		cmd.Process.Kill()
+		logFile.Close()
+		return fmt.Errorf("save classifying state: %w", err)
+	}
+
+	go func() {
+		defer logFile.Close()
+		cmd.Wait()
+	}()
+
+	log.Printf("[classify] %s: classifier spawned (pid=%d)", op.OperationID, op.PID)
+	return nil
+}
+
+// FinishClassify completes the classify phase after the classifier process has exited.
+// It reloads OPERATION.md, checks the squad assignment, and moves the operation to the squad directory.
+func FinishClassify(op *operation.Operation, notifier notify.Notifier) (*operation.Operation, string, error) {
+	reloaded, err := operation.Load("_unclassified", op.OperationID)
+	if err != nil {
+		return nil, "", fmt.Errorf("reload after classify: %v", err)
+	}
+	log.Printf("[classify] %s: classify result — squad=%q", op.OperationID, reloaded.Squad)
+
+	if reloaded.Squad == "" {
+		summaries := squads.ListSummaries()
+		if notifier != nil {
+			notifier.Notify(fmt.Sprintf("Task could not be classified — no matching squad found.\n\nOperation: %s\nBrief: %s\n\nInstalled squads:\n%s", op.OperationID, op.Brief, summaries))
+		}
+		return nil, "", fmt.Errorf("classify failed: no squad assigned")
+	}
+
+	manifestPath := filepath.Join(layout.BlueprintSquadDir(reloaded.Squad), "MANIFEST.md")
+	if !platform.FileExists(manifestPath) {
+		if notifier != nil {
+			notifier.Notify(fmt.Sprintf("Task classified to squad '%s' which is not installed.\n\nOperation: %s\nBrief: %s", reloaded.Squad, op.OperationID, op.Brief))
+		}
+		return nil, "", fmt.Errorf("classify assigned unknown squad: %s", reloaded.Squad)
+	}
+
+	destDir := layout.OperationDir(reloaded.Squad, op.OperationID)
+	if err := os.MkdirAll(filepath.Dir(destDir), 0755); err != nil {
+		return nil, "", fmt.Errorf("create squad dir: %v", err)
+	}
+	if err := os.Rename(unclassifiedDir(op.OperationID), destDir); err != nil {
+		return nil, "", fmt.Errorf("move to squad: %v", err)
+	}
+
+	return reloaded, destDir, nil
+}
+
+// unclassifiedDir is a shorthand for layout.UnclassifiedOperationDir.
+func unclassifiedDir(opID string) string {
+	return layout.UnclassifiedOperationDir(opID)
+}
+
+// buildClassifyPrompt constructs the classifier system prompt.
+func buildClassifyPrompt() string {
+	return fmt.Sprintf(
 		"You are an Operation Classifier. Your job is to route an operation to the right squad and enrich it with relevant context. "+
 			"## Step 1: Read the operation "+
 			"Read OPERATION.md for the brief (H1 title) and details (## Assignment section). "+
@@ -54,58 +136,4 @@ func Classify(rt runtime.RuntimeAdapter, op *operation.Operation, notifier notif
 		layout.BlueprintSquadsDir(),
 		layout.SquadsDir(),
 	)
-
-	cmd := rt.BuildCommand(prompt, unclassifiedDir)
-
-	logPath := filepath.Join(unclassifiedDir, "classify.log")
-	logFile, err := os.Create(logPath)
-	if err != nil {
-		return nil, "", fmt.Errorf("create classify log: %v", err)
-	}
-	cmd.Stdout = logFile
-	cmd.Stderr = logFile
-
-	if err := cmd.Start(); err != nil {
-		logFile.Close()
-		return nil, "", fmt.Errorf("start operation classifier: %v", err)
-	}
-	if err := cmd.Wait(); err != nil {
-		logFile.Close()
-		log.Printf("[classify] %s: operation classifier exited with error: %v", op.OperationID, err)
-	} else {
-		logFile.Close()
-		log.Printf("[classify] %s: operation classifier completed successfully", op.OperationID)
-	}
-
-	reloaded, err := operation.Load("_unclassified", op.OperationID)
-	if err != nil {
-		return nil, "", fmt.Errorf("reload after classify: %v", err)
-	}
-	log.Printf("[classify] %s: classify result — squad=%q", op.OperationID, reloaded.Squad)
-
-	if reloaded.Squad == "" {
-		summaries := squads.ListSummaries()
-		if notifier != nil {
-			notifier.Notify(fmt.Sprintf("Task could not be classified — no matching squad found.\n\nOperation: %s\nBrief: %s\n\nInstalled squads:\n%s", op.OperationID, op.Brief, summaries))
-		}
-		return nil, "", fmt.Errorf("classify failed: no squad assigned")
-	}
-
-	manifestPath := filepath.Join(layout.BlueprintSquadDir(reloaded.Squad), "MANIFEST.md")
-	if !platform.FileExists(manifestPath) {
-		if notifier != nil {
-			notifier.Notify(fmt.Sprintf("Task classified to squad '%s' which is not installed.\n\nOperation: %s\nBrief: %s", reloaded.Squad, op.OperationID, op.Brief))
-		}
-		return nil, "", fmt.Errorf("classify assigned unknown squad: %s", reloaded.Squad)
-	}
-
-	destDir := layout.OperationDir(reloaded.Squad, op.OperationID)
-	if err := os.MkdirAll(filepath.Dir(destDir), 0755); err != nil {
-		return nil, "", fmt.Errorf("create squad dir: %v", err)
-	}
-	if err := os.Rename(unclassifiedDir, destDir); err != nil {
-		return nil, "", fmt.Errorf("move to squad: %v", err)
-	}
-
-	return reloaded, destDir, nil
 }

--- a/commander/pipeline/classify.go
+++ b/commander/pipeline/classify.go
@@ -65,13 +65,9 @@ func SpawnClassify(rt runtime.RuntimeAdapter, op *operation.Operation) error {
 // Reloads OPERATION.md to get classifier output, validates squad, moves to squad dir,
 // provisions, and launches the agent.
 func Advance(rt runtime.RuntimeAdapter, op *operation.Operation, notifier notify.Notifier, runtimeName, notifyName string) error {
-	reloaded, err := operation.Load("_unclassified", op.OperationID)
-	if err != nil {
-		return fmt.Errorf("reload after classify: %v", err)
-	}
-	log.Printf("[classify] %s: classify result — squad=%q", op.OperationID, reloaded.Squad)
+	log.Printf("[classify] %s: classify result — squad=%q", op.OperationID, op.Squad)
 
-	if reloaded.Squad == "" {
+	if op.Squad == "" {
 		summaries := squads.ListSummaries()
 		if notifier != nil {
 			notifier.Notify(fmt.Sprintf("Task could not be classified — no matching squad found.\n\nOperation: %s\nBrief: %s\n\nInstalled squads:\n%s", op.OperationID, op.Brief, summaries))
@@ -79,15 +75,15 @@ func Advance(rt runtime.RuntimeAdapter, op *operation.Operation, notifier notify
 		return fmt.Errorf("classify failed: no squad assigned")
 	}
 
-	manifestPath := filepath.Join(layout.BlueprintSquadDir(reloaded.Squad), "MANIFEST.md")
+	manifestPath := filepath.Join(layout.BlueprintSquadDir(op.Squad), "MANIFEST.md")
 	if !platform.FileExists(manifestPath) {
 		if notifier != nil {
-			notifier.Notify(fmt.Sprintf("Task classified to squad '%s' which is not installed.\n\nOperation: %s\nBrief: %s", reloaded.Squad, op.OperationID, op.Brief))
+			notifier.Notify(fmt.Sprintf("Task classified to squad '%s' which is not installed.\n\nOperation: %s\nBrief: %s", op.Squad, op.OperationID, op.Brief))
 		}
-		return fmt.Errorf("classify assigned unknown squad: %s", reloaded.Squad)
+		return fmt.Errorf("classify assigned unknown squad: %s", op.Squad)
 	}
 
-	destDir := layout.OperationDir(reloaded.Squad, op.OperationID)
+	destDir := layout.OperationDir(op.Squad, op.OperationID)
 	if err := os.MkdirAll(filepath.Dir(destDir), 0755); err != nil {
 		return fmt.Errorf("create squad dir: %v", err)
 	}
@@ -95,15 +91,15 @@ func Advance(rt runtime.RuntimeAdapter, op *operation.Operation, notifier notify
 		return fmt.Errorf("move to squad: %v", err)
 	}
 
-	if err := Provision(rt, reloaded, destDir, runtimeName, notifyName); err != nil {
+	if err := Provision(rt, op, destDir, runtimeName, notifyName); err != nil {
 		return fmt.Errorf("provision: %v", err)
 	}
 
-	if err := LaunchAgent(rt, reloaded, destDir); err != nil {
+	if err := LaunchAgent(rt, op, destDir); err != nil {
 		return fmt.Errorf("launch: %v", err)
 	}
 
-	log.Printf("[scan] %s: launched successfully (squad=%s)", reloaded.OperationID, reloaded.Squad)
+	log.Printf("[scan] %s: launched successfully (squad=%s)", op.OperationID, op.Squad)
 	return nil
 }
 

--- a/commander/pipeline/classify.go
+++ b/commander/pipeline/classify.go
@@ -90,16 +90,11 @@ func FinishClassify(op *operation.Operation, notifier notify.Notifier) (*operati
 	if err := os.MkdirAll(filepath.Dir(destDir), 0755); err != nil {
 		return nil, "", fmt.Errorf("create squad dir: %v", err)
 	}
-	if err := os.Rename(unclassifiedDir(op.OperationID), destDir); err != nil {
+	if err := os.Rename(layout.UnclassifiedOperationDir(op.OperationID), destDir); err != nil {
 		return nil, "", fmt.Errorf("move to squad: %v", err)
 	}
 
 	return reloaded, destDir, nil
-}
-
-// unclassifiedDir is a shorthand for layout.UnclassifiedOperationDir.
-func unclassifiedDir(opID string) string {
-	return layout.UnclassifiedOperationDir(opID)
 }
 
 // buildClassifyPrompt constructs the classifier system prompt.

--- a/commander/pipeline/collect.go
+++ b/commander/pipeline/collect.go
@@ -1,0 +1,37 @@
+package pipeline
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/LangSensei/swat/commander/layout"
+	"github.com/LangSensei/swat/commander/operation"
+	"github.com/LangSensei/swat/commander/platform"
+)
+
+// Collect checks if a finished operation completed successfully or failed,
+// and updates its status accordingly.
+func Collect(op *operation.Operation) error {
+	opDir := layout.OperationDir(op.Squad, op.OperationID)
+	reportExists := platform.FileExists(filepath.Join(opDir, "report.html"))
+	opCompleted := platform.FileContains(layout.OperationMDPath(op.Squad, op.OperationID), "status: completed")
+
+	now := time.Now().UTC()
+	if reportExists && opCompleted {
+		op.Status = "completed"
+		op.CompletedAt = &now
+		op.PID = 0
+	} else {
+		reason := "process_exited_without_completion"
+		op.Status = "failed"
+		op.FailedAt = &now
+		op.FailureReason = &reason
+		op.PID = 0
+	}
+
+	if err := operation.Save(op); err != nil {
+		return fmt.Errorf("save collected state: %w", err)
+	}
+	return nil
+}

--- a/mcp/handlers.go
+++ b/mcp/handlers.go
@@ -191,7 +191,7 @@ func (s *Server) handleList(args map[string]interface{}) toolResult {
 	}
 
 	// Compute counts before filtering
-	counts := map[string]int{"queued": 0, "active": 0, "completed": 0, "failed": 0}
+	counts := map[string]int{"queued": 0, "classifying": 0, "active": 0, "completed": 0, "failed": 0}
 	for _, op := range ops {
 		counts[op.Status]++
 	}
@@ -217,7 +217,7 @@ func (s *Server) handleList(args map[string]interface{}) toolResult {
 					filtered = append(filtered, op)
 				} else if op.FailedAt != nil && op.FailedAt.After(sinceTime) {
 					filtered = append(filtered, op)
-				} else if op.Status == "active" || op.Status == "queued" {
+				} else if op.Status == "active" || op.Status == "queued" || op.Status == "classifying" {
 					filtered = append(filtered, op) // always include in-flight
 				}
 			}

--- a/mcp/mcp.go
+++ b/mcp/mcp.go
@@ -48,7 +48,7 @@ func (s *Server) Tools() []ToolDef {
 			InputSchema: map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{
-					"status": map[string]interface{}{"type": "string", "description": "Filter by status (queued/active/completed/failed)"},
+					"status": map[string]interface{}{"type": "string", "description": "Filter by status (queued/classifying/active/completed/failed)"},
 					"since":  map[string]interface{}{"type": "string", "description": "Only return terminal ops after this RFC3339 timestamp"},
 					"limit":  map[string]interface{}{"type": "integer", "description": "Max results to return (default 50)"},
 					"offset": map[string]interface{}{"type": "integer", "description": "Skip first N results (default 0)"},


### PR DESCRIPTION
## What
Refactor Commander BackgroundLoop so classify runs as a non-blocking subprocess. Multiple operations can classify in parallel. The scan loop advances each operation one step per tick based on status + PID liveness.

## Why
Previously, `processOperation()` ran the classify→provision→launch pipeline synchronously, blocking the scan loop during LLM classification. This prevented parallel classify and made the Commander unresponsive during long-running classify operations.

Closes #93

## Changes
- **commander/pipeline/classify.go**: Split `Classify()` into `SpawnClassify()` (non-blocking start) and `FinishClassify()` (post-classify move + validation)
- **commander/commander.go**: Rewrite `scan()` as a state machine handling `queued`, `classifying`, and `active` statuses. Added `spawnClassify()` and `finishClassify()` methods
- **commander/dispatch.go**: Remove `processOperation()`. Simplify intake callbacks to just create queued ops. `failOperation()` now clears PID and sends notifications. `Cancel()` handles `classifying` status
- **commander/operation/operation.go**: `Save()` always writes `pid` field (even 0) to prevent stale PIDs
- **mcp/handlers.go** + **mcp/mcp.go**: Add `classifying` to status counts, since filter, and description

## State Machine
```
Status       | PID    | scan behavior
sudo su
queued       | 0      | spawn classify → pid=N → status=classifying
classifying  | alive  | skip (wait)
classifying  | dead   | check squad → move + provision + launch → status=active
active       | alive  | skip (agent running)
active       | dead   | check report.html + status → completed or failed
completed    | 0      | skip
failed       | 0      | skip
```

## How to Test
1. `go build ./...` — passes
2. `go vet ./...` — passes
3. `go test ./...` — passes
4. Deploy and dispatch multiple operations simultaneously — they should classify in parallel