### PR TITLE
refactor: standardize failure_reason to enumerated identifiers

### DIFF
--- a/commander/commander.go
+++ b/commander/commander.go
@@ -78,7 +78,7 @@ func (c *Commander) scan() {
 		case "queued":
 			c.withLock(op, layout.UnclassifiedOperationDir(op.OperationID), "queued", func(reloaded *operation.Operation) {
 				if err := pipeline.SpawnClassify(rt, reloaded); err != nil {
-					c.failOperation(reloaded, fmt.Sprintf("classify spawn: %v", err))
+					c.failOperation(reloaded, err.Error())
 				}
 			})
 		case "classifying":

--- a/commander/pipeline/classify.go
+++ b/commander/pipeline/classify.go
@@ -20,7 +20,8 @@ func SpawnClassify(rt runtime.RuntimeAdapter, op *operation.Operation) error {
 	unclassifiedDir := layout.UnclassifiedOperationDir(op.OperationID)
 
 	if err := rt.PrepareWorkspace(unclassifiedDir, runtime.PhaseClassify); err != nil {
-		return fmt.Errorf("prepare workspace (classify): %v", err)
+		log.Printf("[classify] %s: prepare workspace error: %v", op.OperationID, err)
+		return fmt.Errorf("classify_spawn_failed")
 	}
 
 	prompt := buildClassifyPrompt()
@@ -30,14 +31,16 @@ func SpawnClassify(rt runtime.RuntimeAdapter, op *operation.Operation) error {
 	logPath := filepath.Join(unclassifiedDir, "classify.log")
 	logFile, err := os.Create(logPath)
 	if err != nil {
-		return fmt.Errorf("create classify log: %v", err)
+		log.Printf("[classify] %s: create log error: %v", op.OperationID, err)
+		return fmt.Errorf("classify_spawn_failed")
 	}
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 
 	if err := cmd.Start(); err != nil {
 		logFile.Close()
-		return fmt.Errorf("start operation classifier: %v", err)
+		log.Printf("[classify] %s: spawn error: %v", op.OperationID, err)
+		return fmt.Errorf("classify_spawn_failed")
 	}
 
 	now := time.Now().UTC()
@@ -48,7 +51,8 @@ func SpawnClassify(rt runtime.RuntimeAdapter, op *operation.Operation) error {
 	if err := operation.Save(op); err != nil {
 		cmd.Process.Kill()
 		logFile.Close()
-		return fmt.Errorf("save classifying state: %w", err)
+		log.Printf("[classify] %s: save state error: %v", op.OperationID, err)
+		return fmt.Errorf("classify_spawn_failed")
 	}
 
 	go func() {
@@ -68,28 +72,34 @@ func Advance(rt runtime.RuntimeAdapter, op *operation.Operation, runtimeName, no
 
 	if op.Squad == "" {
 		summaries := squads.ListSummaries()
-		return fmt.Errorf("no matching squad found\n\nInstalled squads:\n%s", summaries)
+		log.Printf("[classify] %s: no squad match. Installed squads:\n%s", op.OperationID, summaries)
+		return fmt.Errorf("classify_no_squad")
 	}
 
 	manifestPath := filepath.Join(layout.BlueprintSquadDir(op.Squad), "MANIFEST.md")
 	if !platform.FileExists(manifestPath) {
-		return fmt.Errorf("classified to squad '%s' which is not installed", op.Squad)
+		log.Printf("[classify] %s: squad %q not installed (no MANIFEST.md)", op.OperationID, op.Squad)
+		return fmt.Errorf("classify_squad_not_installed")
 	}
 
 	destDir := layout.OperationDir(op.Squad, op.OperationID)
 	if err := os.MkdirAll(filepath.Dir(destDir), 0755); err != nil {
-		return fmt.Errorf("create squad dir: %v", err)
+		log.Printf("[classify] %s: create squad dir error: %v", op.OperationID, err)
+		return fmt.Errorf("classify_move_failed")
 	}
 	if err := os.Rename(layout.UnclassifiedOperationDir(op.OperationID), destDir); err != nil {
-		return fmt.Errorf("move to squad: %v", err)
+		log.Printf("[classify] %s: move to squad error: %v", op.OperationID, err)
+		return fmt.Errorf("classify_move_failed")
 	}
 
 	if err := Provision(rt, op, destDir, runtimeName, notifyName); err != nil {
-		return fmt.Errorf("provision: %v", err)
+		log.Printf("[classify] %s: provision error: %v", op.OperationID, err)
+		return fmt.Errorf("provision_failed")
 	}
 
 	if err := LaunchAgent(rt, op, destDir); err != nil {
-		return fmt.Errorf("launch: %v", err)
+		log.Printf("[classify] %s: launch error: %v", op.OperationID, err)
+		return fmt.Errorf("launch_failed")
 	}
 
 	log.Printf("[scan] %s: launched successfully (squad=%s)", op.OperationID, op.Squad)


### PR DESCRIPTION
## What
Replaces free-form error strings in `failure_reason` with short, machine-parseable identifiers.

## Why
Free-form error messages in `failure_reason` are hard to parse programmatically. Enumerated identifiers enable reliable matching/filtering while detailed error info remains in log files.

## Changes
- `commander/pipeline/classify.go`: All error returns in `SpawnClassify` now return `classify_spawn_failed` with details logged via `log.Printf`. All error returns in `Advance` now return specific identifiers (`classify_no_squad`, `classify_squad_not_installed`, `classify_move_failed`, `provision_failed`, `launch_failed`) with details logged.
- `commander/commander.go`: `scan()` no longer wraps `SpawnClassify` errors with `classify spawn: %v` — passes `err.Error()` directly since errors are already identifiers.

## Enumerated Identifiers
| Identifier | When |
|---|---|
| `cancelled_by_user` | Cancel() called (unchanged) |
| `process_exited_without_completion` | Collect finds no completion (unchanged) |
| `classify_spawn_failed` | SpawnClassify returns error |
| `classify_no_squad` | No matching squad after classify |
| `classify_squad_not_installed` | Squad MANIFEST.md missing |
| `classify_move_failed` | os.Rename or dir creation fails |
| `provision_failed` | Provision returns error |
| `launch_failed` | LaunchAgent returns error |

## How to Test
```bash
go build ./...
go test ./...
```
Verify failure_reason values in OPERATION.md frontmatter after triggering each failure path.