### PR TITLE
fix: move per-operation flock to global locks directory

### DIFF
--- a/commander/commander.go
+++ b/commander/commander.go
@@ -75,14 +75,14 @@ func (c *Commander) scan() {
 	for _, op := range ops {
 		switch op.Status {
 		case "queued":
-			c.withLock(op, layout.UnclassifiedOperationDir(op.OperationID), "queued", func(reloaded *operation.Operation) {
+			c.withLock(op, "queued", func(reloaded *operation.Operation) {
 				if err := pipeline.SpawnClassify(rt, reloaded); err != nil {
 					c.failOperation(reloaded, err.Error())
 				}
 			})
 		case "classifying":
 			if !platform.ProcessAlive(op.PID) {
-				c.withLock(op, layout.UnclassifiedOperationDir(op.OperationID), "classifying", func(reloaded *operation.Operation) {
+				c.withLock(op, "classifying", func(reloaded *operation.Operation) {
 					if err := pipeline.Advance(rt, reloaded, c.RuntimeName, c.NotifyName); err != nil {
 						c.failOperation(reloaded, err.Error())
 					}
@@ -92,7 +92,7 @@ func (c *Commander) scan() {
 			if op.PID > 0 && platform.ProcessAlive(op.PID) {
 				continue
 			}
-			c.withLock(op, layout.OperationDir(op.Squad, op.OperationID), "active", func(reloaded *operation.Operation) {
+			c.withLock(op, "active", func(reloaded *operation.Operation) {
 				if err := pipeline.Collect(reloaded); err != nil {
 					log.Printf("[scan] %s: collect save error: %v", reloaded.OperationID, err)
 					return
@@ -113,7 +113,7 @@ func (c *Commander) scan() {
 
 // withLock acquires a per-operation flock, double-checks status, and calls fn.
 // Recovers from panics to prevent BackgroundLoop from crashing.
-func (c *Commander) withLock(op *operation.Operation, opDir string, expectedStatus string, fn func(reloaded *operation.Operation)) {
+func (c *Commander) withLock(op *operation.Operation, expectedStatus string, fn func(reloaded *operation.Operation)) {
 	defer func() {
 		if r := recover(); r != nil {
 			log.Printf("[scan] PANIC in %s: %v", op.OperationID, r)

--- a/commander/commander.go
+++ b/commander/commander.go
@@ -4,7 +4,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"log"
-	"path/filepath"
 	"time"
 
 	"github.com/LangSensei/swat/commander/intake"
@@ -122,7 +121,7 @@ func (c *Commander) withLock(op *operation.Operation, opDir string, expectedStat
 		}
 	}()
 
-	lockPath := filepath.Join(opDir, ".lock")
+	lockPath := layout.LockPath(op.OperationID)
 	fl := flock.New(lockPath)
 	locked, err := fl.TryLock()
 	if !locked || err != nil {

--- a/commander/layout/layout.go
+++ b/commander/layout/layout.go
@@ -68,6 +68,14 @@ func UnclassifiedOperationDir(opID string) string { return OperationDir("_unclas
 // UnclassifiedOperationMDPath returns the OPERATION.md path for an unclassified operation.
 func UnclassifiedOperationMDPath(opID string) string { return OperationMDPath("_unclassified", opID) }
 
+// --- Locks ---
+
+// LocksDir returns the global per-operation locks directory.
+func LocksDir() string { return filepath.Join(root, "locks") }
+
+// LockPath returns the lock file path for a given operation ID.
+func LockPath(opID string) string { return filepath.Join(LocksDir(), opID+".lock") }
+
 // --- Intake ---
 
 // IntakeDir returns the intake queue directory.
@@ -85,6 +93,7 @@ func EnsureDirs() {
 		BlueprintMCPsDir(),
 		SquadsDir(),
 		UnclassifiedOperationsDir(),
+		LocksDir(),
 	} {
 		os.MkdirAll(dir, 0755)
 	}


### PR DESCRIPTION
## What
Move per-operation lock files from inside operation directories to a dedicated global locks directory (`~/.swat/locks/{opID}.lock`).

## Why
On Windows, `withLock` holds a `.lock` file handle inside the operation directory. When `Advance` tries to `os.Rename` that directory (e.g., moving from `_unclassified` to a squad), Windows fails because a file handle is open inside it.

## Changes
- `commander/layout/layout.go`: Add `LocksDir()` and `LockPath(opID)` helpers; register `LocksDir()` in `EnsureDirs()`
- `commander/commander.go`: Use `layout.LockPath(op.OperationID)` instead of `filepath.Join(opDir, ".lock")`; remove unused `path/filepath` import

## How to Test
```bash
go build ./...
go test ./...
```
Verify on Windows that operation classification (rename from `_unclassified` to squad dir) no longer fails with "file in use" errors.