### PR TITLE
feat: add opID to Notifier interface and Windows toast launch-to-report

### DIFF
--- a/commander/commander.go
+++ b/commander/commander.go
@@ -102,7 +102,7 @@ func (c *Commander) scan() {
 				if reloaded.Status == "failed" && c.Notifier != nil {
 					reason := "process_exited_without_completion"
 					msg := fmt.Sprintf("Operation %s failed: %s", reloaded.OperationID, reason)
-					if err := c.Notifier.Notify(msg); err != nil {
+					if err := c.Notifier.Notify(reloaded.OperationID, msg); err != nil {
 						log.Printf("[scan] notify error: %v", err)
 					}
 				}

--- a/commander/dispatch.go
+++ b/commander/dispatch.go
@@ -44,7 +44,7 @@ func (c *Commander) failOperation(op *operation.Operation, reason string) error 
 
 	if c.Notifier != nil {
 		msg := fmt.Sprintf("Operation %s failed: %s", op.OperationID, reason)
-		if err := c.Notifier.Notify(msg); err != nil {
+		if err := c.Notifier.Notify(op.OperationID, msg); err != nil {
 			log.Printf("[dispatch] %s: notify error: %v", op.OperationID, err)
 		}
 	}

--- a/commander/notify/desktop.go
+++ b/commander/notify/desktop.go
@@ -3,10 +3,15 @@ package notify
 import (
 	"encoding/base64"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"unicode/utf16"
+
+	"github.com/LangSensei/swat/commander/layout"
+	"github.com/LangSensei/swat/commander/operation"
 )
 
 // DesktopNotifier sends native desktop notifications via OS-specific commands.
@@ -14,7 +19,8 @@ type DesktopNotifier struct{}
 
 // Notify sends a desktop notification. Uses osascript on macOS,
 // notify-send on Linux, and PowerShell toast on Windows.
-func (d *DesktopNotifier) Notify(message string) error {
+// On Windows, if opID resolves to a report.html, clicking the toast opens it.
+func (d *DesktopNotifier) Notify(opID string, message string) error {
 	switch runtime.GOOS {
 	case "darwin":
 		script := fmt.Sprintf(`display notification %q with title "SWAT"`, message)
@@ -22,20 +28,44 @@ func (d *DesktopNotifier) Notify(message string) error {
 	case "linux":
 		return exec.Command("notify-send", "SWAT", message).Run()
 	case "windows":
+		reportPath := findReportPath(opID)
+		launchAttr := ""
+		if reportPath != "" {
+			// Convert to file:/// URL with forward slashes
+			fileURL := "file:///" + strings.ReplaceAll(reportPath, `\`, "/")
+			launchAttr = fmt.Sprintf(` launch="%s" activationType="protocol"`, fileURL)
+		}
 		ps := fmt.Sprintf(
 			`[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] > $null; `+
-				`$xml = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent(0); `+
-				`$text = $xml.GetElementsByTagName('text'); `+
-				`$text.Item(0).AppendChild($xml.CreateTextNode('%s')) > $null; `+
-				`$toast = [Windows.UI.Notifications.ToastNotification]::new($xml); `+
+				`[Windows.Data.Xml.Dom.XmlDocument, Windows.Data.Xml.Dom, ContentType = WindowsRuntime] > $null; `+
+				`$xml = '<toast%s><visual><binding template="ToastGeneric"><text>SWAT</text><text>%s</text></binding></visual></toast>'; `+
+				`$doc = [Windows.Data.Xml.Dom.XmlDocument]::new(); `+
+				`$doc.LoadXml($xml); `+
+				`$toast = [Windows.UI.Notifications.ToastNotification]::new($doc); `+
 				`[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('SWAT').Show($toast)`,
-			strings.ReplaceAll(message, "'", "''"),
+			launchAttr, strings.ReplaceAll(message, "'", "''"),
 		)
 		encoded := encodeUTF16LEBase64(ps)
 		return exec.Command("powershell", "-NoProfile", "-EncodedCommand", encoded).Run()
 	default:
 		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
 	}
+}
+
+// findReportPath resolves the report.html path for an operation.
+func findReportPath(opID string) string {
+	if opID == "" {
+		return ""
+	}
+	op, err := operation.Find(opID)
+	if err != nil || op.Squad == "" {
+		return ""
+	}
+	reportPath := filepath.Join(layout.OperationDir(op.Squad, opID), "report.html")
+	if _, err := os.Stat(reportPath); err == nil {
+		return reportPath
+	}
+	return ""
 }
 
 // encodeUTF16LEBase64 converts a string to UTF-16LE bytes and then base64-encodes it,

--- a/commander/notify/desktop.go
+++ b/commander/notify/desktop.go
@@ -3,6 +3,7 @@ package notify
 import (
 	"encoding/base64"
 	"fmt"
+	"html"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -33,8 +34,10 @@ func (d *DesktopNotifier) Notify(opID string, message string) error {
 		if reportPath != "" {
 			// Convert to file:/// URL with forward slashes
 			fileURL := "file:///" + strings.ReplaceAll(reportPath, `\`, "/")
-			launchAttr = fmt.Sprintf(` launch="%s" activationType="protocol"`, fileURL)
+			safeURL := html.EscapeString(fileURL)
+			launchAttr = fmt.Sprintf(` launch="%s" activationType="protocol"`, safeURL)
 		}
+		safeMessage := html.EscapeString(message)
 		ps := fmt.Sprintf(
 			`[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] > $null; `+
 				`[Windows.Data.Xml.Dom.XmlDocument, Windows.Data.Xml.Dom, ContentType = WindowsRuntime] > $null; `+
@@ -43,7 +46,7 @@ func (d *DesktopNotifier) Notify(opID string, message string) error {
 				`$doc.LoadXml($xml); `+
 				`$toast = [Windows.UI.Notifications.ToastNotification]::new($doc); `+
 				`[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('SWAT').Show($toast)`,
-			launchAttr, strings.ReplaceAll(message, "'", "''"),
+			launchAttr, safeMessage,
 		)
 		encoded := encodeUTF16LEBase64(ps)
 		return exec.Command("powershell", "-NoProfile", "-EncodedCommand", encoded).Run()

--- a/commander/notify/notify.go
+++ b/commander/notify/notify.go
@@ -8,7 +8,7 @@ import (
 
 // Notifier sends user-facing notifications.
 type Notifier interface {
-	Notify(message string) error
+	Notify(opID string, message string) error
 }
 
 // New creates a Notifier for the given target name.

--- a/commander/notify/openclaw.go
+++ b/commander/notify/openclaw.go
@@ -122,7 +122,7 @@ func newOpenClawNotifier() (*OpenClawNotifier, error) {
 
 // Notify sends a notification via the OpenClaw Gateway API.
 // Retries up to 2 times with a 2-second delay between attempts.
-func (o *OpenClawNotifier) Notify(message string) error {
+func (o *OpenClawNotifier) Notify(opID string, message string) error {
 	args := map[string]string{
 		"action":  "send",
 		"target":  o.target,

--- a/mcp/handlers.go
+++ b/mcp/handlers.go
@@ -508,7 +508,7 @@ func (s *Server) handleNotify(args map[string]interface{}) toolResult {
 		}
 	}
 
-	if err := s.Notifier.Notify(message); err != nil {
+	if err := s.Notifier.Notify("", message); err != nil {
 		return toolResult{
 			Content: []contentBlock{{Type: "text", Text: fmt.Sprintf("notify failed: %v", err)}},
 			IsError: true,


### PR DESCRIPTION
## What
Add `opID` parameter to the `Notifier` interface and implement Windows toast launch-to-report support.

## Why
When a SWAT operation completes and sends a desktop notification, clicking the toast should open the operation's `report.html` in the default browser. This requires the notifier to know which operation triggered the notification.

## Changes
- `commander/notify/notify.go`: Updated `Notifier` interface signature to `Notify(opID string, message string) error`
- `commander/notify/desktop.go`: Windows toast now uses custom XML with `launch` attribute pointing to `report.html` via `file:///` URL; added `findReportPath` helper using `operation.Find` and `layout.OperationDir`
- `commander/notify/openclaw.go`: Updated signature (opID unused)
- `commander/commander.go`: Pass `reloaded.OperationID` to `Notify`
- `commander/dispatch.go`: Pass `op.OperationID` to `Notify`
- `mcp/handlers.go`: Pass empty string for opID (MCP server is not operation-scoped)

## How to Test
1. `go build ./...` — passes
2. `go test ./...` — passes
3. `go vet ./...` — passes
4. On Windows: trigger a notification for a completed operation with `report.html` and verify clicking the toast opens the report