### PR TITLE
feat: add optional operation_id parameter to swat_notify MCP tool

### DIFF
--- a/mcp/handlers.go
+++ b/mcp/handlers.go
@@ -494,6 +494,7 @@ func (s *Server) errorResponse(id interface{}, code int, msg string) *jsonrpcRes
 
 func (s *Server) handleNotify(args map[string]interface{}) toolResult {
 	message, _ := args["message"].(string)
+	opID, _ := args["operation_id"].(string)
 	if message == "" {
 		return toolResult{
 			Content: []contentBlock{{Type: "text", Text: "message is required"}},
@@ -508,7 +509,7 @@ func (s *Server) handleNotify(args map[string]interface{}) toolResult {
 		}
 	}
 
-	if err := s.Notifier.Notify("", message); err != nil {
+	if err := s.Notifier.Notify(opID, message); err != nil {
 		return toolResult{
 			Content: []contentBlock{{Type: "text", Text: fmt.Sprintf("notify failed: %v", err)}},
 			IsError: true,

--- a/mcp/mcp.go
+++ b/mcp/mcp.go
@@ -156,7 +156,8 @@ func (s *Server) Tools() []ToolDef {
 			InputSchema: map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{
-					"message": map[string]interface{}{"type": "string", "description": "Notification message to display"},
+					"message":      map[string]interface{}{"type": "string", "description": "Notification message to display"},
+					"operation_id": map[string]interface{}{"type": "string", "description": "Operation ID (enables report link in desktop notification)"},
 				},
 				"required": []string{"message"},
 			},


### PR DESCRIPTION
## What
Add optional `operation_id` parameter to the `swat_notify` MCP tool so operators can pass operation IDs through to desktop notifications.

## Why
PR #98 added `opID` as the first parameter to the `Notifier` interface, but the MCP tool handler was hardcoding an empty string. This change adds the MCP-side plumbing so the operation ID flows from the tool call through to the notifier, enabling report links in desktop notifications.

## Changes
- `mcp/mcp.go`: Added `operation_id` as an optional string property to the `swat_notify` inputSchema
- `mcp/handlers.go`: Read `operation_id` from tool arguments and pass to `Notify()` instead of empty string

## How to Test
```bash
go build ./...
go test ./...
```
Both pass. The change is backward compatible — `operation_id` is optional and defaults to empty string when not provided.