### PR TITLE
fix: register Windows AUMID and force PowerShell 5.1 path for toast notifications

### DIFF
--- a/commander/notify/desktop.go
+++ b/commander/notify/desktop.go
@@ -39,7 +39,14 @@ func (d *DesktopNotifier) Notify(opID string, message string) error {
 		}
 		safeMessage := html.EscapeString(message)
 		ps := fmt.Sprintf(
-			`[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] > $null; `+
+			// Register AUMID so Windows does not silently swallow the toast
+			`$aumid = 'SWAT'; `+
+				`$regPath = "HKCU:\Software\Classes\AppUserModelId\$aumid"; `+
+				`if (-not (Test-Path $regPath)) { `+
+				`New-Item -Path $regPath -Force | Out-Null; `+
+				`New-ItemProperty -Path $regPath -Name DisplayName -Value 'SWAT' -Force | Out-Null }; `+
+				// Load WinRT types and send toast
+				`[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] > $null; `+
 				`[Windows.Data.Xml.Dom.XmlDocument, Windows.Data.Xml.Dom, ContentType = WindowsRuntime] > $null; `+
 				`$xml = '<toast%s><visual><binding template="ToastGeneric"><text>SWAT</text><text>%s</text></binding></visual></toast>'; `+
 				`$doc = [Windows.Data.Xml.Dom.XmlDocument]::new(); `+
@@ -49,7 +56,11 @@ func (d *DesktopNotifier) Notify(opID string, message string) error {
 			launchAttr, safeMessage,
 		)
 		encoded := encodeUTF16LEBase64(ps)
-		return exec.Command("powershell", "-NoProfile", "-EncodedCommand", encoded).Run()
+		ps51 := filepath.Join(os.Getenv("SystemRoot"), "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+		if os.Getenv("SystemRoot") == "" {
+			ps51 = "powershell"
+		}
+		return exec.Command(ps51, "-NoProfile", "-EncodedCommand", encoded).Run()
 	default:
 		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
 	}


### PR DESCRIPTION
## What
Fix Windows toast notifications silently failing due to unregistered AUMID and potential PowerShell 7 resolution.

## Why
1. **Unregistered AUMID** — Windows swallows toasts from apps without a registered AppUserModelId. The AppID `SWAT` was passed to `CreateToastNotifier()` but never registered in the registry.
2. **Wrong PowerShell version** — `exec.Command("powershell", ...)` can resolve to PowerShell 7 (pwsh) on systems where PS 7 is installed, but the WinRT toast API only works in PowerShell 5.1.

## Changes
- `commander/notify/desktop.go`: 
  - Added AUMID registry registration (`HKCU:\Software\Classes\AppUserModelId\SWAT`) at the start of the PowerShell script
  - Replaced bare `powershell` with full PS 5.1 path (`SystemRoot\System32\WindowsPowerShell\v1.0\powershell.exe`)
  - Added fallback to `powershell` if `SystemRoot` env var is empty

## How to Test
1. On a Windows machine, run a SWAT operation that triggers a notification
2. Verify the toast appears in the Windows notification center
3. Verify the registry key `HKCU:\Software\Classes\AppUserModelId\SWAT` is created after first notification
4. `go build ./...` and `go test ./...` pass