### PR TITLE
refactor: extract SystemRoot env var to local variable

### DIFF
--- a/commander/notify/desktop.go
+++ b/commander/notify/desktop.go
@@ -56,8 +56,9 @@ func (d *DesktopNotifier) Notify(opID string, message string) error {
 			launchAttr, safeMessage,
 		)
 		encoded := encodeUTF16LEBase64(ps)
-		ps51 := filepath.Join(os.Getenv("SystemRoot"), "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
-		if os.Getenv("SystemRoot") == "" {
+		sysRoot := os.Getenv("SystemRoot")
+		ps51 := filepath.Join(sysRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+		if sysRoot == "" {
 			ps51 = "powershell"
 		}
 		return exec.Command(ps51, "-NoProfile", "-EncodedCommand", encoded).Run()


### PR DESCRIPTION
## What
Extract `os.Getenv("SystemRoot")` into a local variable in `commander/notify/desktop.go` to avoid a double call and theoretical TOCTOU issue.

## Why
Code review on PR #100 suggested storing the environment variable in a local for clarity and to avoid calling `os.Getenv` twice (once in `filepath.Join`, once in the empty check).

## Changes
- `commander/notify/desktop.go`: Store `os.Getenv("SystemRoot")` in `sysRoot` local variable, use it in both `filepath.Join` and the empty-string guard.

## How to Test
`go build ./...` — compile check passes. Behavior is identical; this is a clarity refactor only.