### PR TITLE
fix: normalize CRLF in parseOperationMD and add YAML compliance note

### DIFF
--- a/blueprints/squads/_framework/PROTOCOL.md
+++ b/blueprints/squads/_framework/PROTOCOL.md
@@ -70,6 +70,7 @@ Re-read your working files (as defined by the skill). Confirm all sections are f
 - Set `summary:` in frontmatter (2-3 sentences)
 - Set `completed_at:` timestamp
 - Set `status: completed`
+- **YAML compliance** — frontmatter values must be valid YAML. If a value contains special characters (`: `, ` #`, `{`, `}`, `[`, `]`, `"`, `'`, `,`), wrap it in double quotes: `summary: "Fixed: auth token refresh"`
 
 ### 3. Generate report.html
 

--- a/commander/operation/serialize.go
+++ b/commander/operation/serialize.go
@@ -85,6 +85,9 @@ func formatOptionalStr(s *string) string {
 // parseOperationMD parses an OPERATION.md file into an Operation struct.
 // Frontmatter is parsed with yaml.v3; body (Brief/Details) is extracted with string logic.
 func parseOperationMD(content string) (*Operation, error) {
+	// Normalize CRLF to LF — Windows editors (and some agent tools) may write CRLF.
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+
 	fmStr, body, err := splitFrontmatter(content)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What
Fix OPERATION.md parsing failures caused by CRLF line endings and unquoted YAML special characters.

## Why
1. On Windows, agent edit tools write CRLF line endings. `parseOperationMD()` did not normalize these, causing body/brief parsing to produce empty results.
2. Operator-written `summary:` values containing `: ` or ` #` break `yaml.Unmarshal`, causing the entire operation to disappear from listings.

## Changes
- `commander/operation/serialize.go`: Add `strings.ReplaceAll(content, "\r\n", "\n")` at the start of `parseOperationMD()`
- `blueprints/squads/_framework/PROTOCOL.md`: Add YAML compliance guidance for frontmatter values with special characters

## How to Test
```bash
go build ./...
go test ./...
```
Both pass. The CRLF fix can be verified by feeding a CRLF-encoded OPERATION.md to `parseOperationMD()`.